### PR TITLE
Add maturation-scheduling model (IPPDP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,10 @@ jobs:
       # correctly fix it to the git source. Force it explicitly here too,
       # regardless of that asymmetry, until a registry release makes this
       # unnecessary (see the comment on [sources] in Project.toml).
-      - run: julia --project=. -e 'using Pkg; Pkg.add(url="https://github.com/SupplyChef/SupplyChainModeling.jl", rev="main")'
+      # TEMPORARY: pinned to claude/cirrelt-2026-poultry-m1z7fv (not main) while
+      # MaturationSource/QuotaSink are only on that SupplyChainModeling branch - see the
+      # matching [sources] comment in Project.toml for why, and revert alongside it.
+      - run: julia --project=. -e 'using Pkg; Pkg.add(url="https://github.com/SupplyChef/SupplyChainModeling.jl", rev="claude/cirrelt-2026-poultry-m1z7fv")'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,7 @@ jobs:
       # correctly fix it to the git source. Force it explicitly here too,
       # regardless of that asymmetry, until a registry release makes this
       # unnecessary (see the comment on [sources] in Project.toml).
-      # TEMPORARY: pinned to claude/cirrelt-2026-poultry-m1z7fv (not main) while
-      # MaturationSource/QuotaSink are only on that SupplyChainModeling branch - see the
-      # matching [sources] comment in Project.toml for why, and revert alongside it.
-      - run: julia --project=. -e 'using Pkg; Pkg.add(url="https://github.com/SupplyChef/SupplyChainModeling.jl", rev="claude/cirrelt-2026-poultry-m1z7fv")'
+      - run: julia --project=. -e 'using Pkg; Pkg.add(url="https://github.com/SupplyChef/SupplyChainModeling.jl", rev="main")'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/CASE_STUDY.md
+++ b/CASE_STUDY.md
@@ -1,0 +1,142 @@
+# Case study: from an academic paper to open-source optimization in a week
+
+**TL;DR:** We took a 2026 operations-research paper on poultry production-distribution
+scheduling, implemented its exact mixed-integer model in
+[SupplyChainOptimization.jl](https://github.com/SupplyChef/SupplyChainOptimization.jl), then
+generalized the implementation so it isn't about poultry at all — it's about *any* supply chain
+where a batch's value grows while it's held and must ship to meet a periodic delivery target.
+Cheese aging, wine maturation, and shelf-life produce inventory all fit the same two node types.
+
+## The paper
+
+Gbéya, Darvish, Renaud and Coelho (2026), *"Integrated Poultry Production-Distribution
+Optimization,"* CIRRELT-2026-10, models a real operational problem: a network of farms each
+raise one flock of birds at a time. A bird's weight grows roughly linearly with age, but only a
+band of weights around a target is sellable at full value — under- or over-shoot it and you eat
+a discount. Each farm chooses when to start a new flock and when to ship it, and slaughterhouses
+have daily intake quotas they'd rather hit than miss (in either direction). The paper calls this
+the **Integrated Poultry Production-Distribution Problem (IPPDP)** and formulates it as a MILP:
+choose every farm's start day, ship day, and destination to minimize transportation cost plus
+weight-deviation penalties plus quota-deviation penalties.
+
+## The implementation
+
+`SupplyChainOptimization.create_maturation_scheduling_model` builds the paper's formulation
+directly — the same binary start/ship-day variables, the same quota-deviation variables, the
+same four-way cost decomposition the paper reports in its Figure 2:
+
+```
+OF = OF_d (transportation) + OF_w (weight/value deviation) + OF_q+ (overproduction) + OF_q- (underproduction)
+```
+
+But nothing about *how* a batch's value evolves is hard-coded. A farm is a
+[`MaturationSource`](https://github.com/SupplyChef/SupplyChainModeling.jl) — a location holding
+one batch at a time, exposing three functions of duration: `value_function`, `feasible_duration`,
+and `duration_penalty`. A slaughterhouse is a [`QuotaSink`](https://github.com/SupplyChef/SupplyChainModeling.jl) —
+a location with a soft periodic delivery target. The model only ever calls those three functions;
+it never assumes birds, weight, or growth.
+
+```mermaid
+flowchart LR
+    subgraph Sources["MaturationSource (one batch at a time)"]
+        F1["Farm A<br/>value_function(duration)<br/>feasible_duration(duration)<br/>duration_penalty(duration)"]
+        F2["Farm B<br/>..."]
+        F3["Farm C<br/>..."]
+    end
+    subgraph Model["create_maturation_scheduling_model"]
+        M["choose start day u,<br/>ship day t, destination s<br/>for every source"]
+    end
+    subgraph Sinks["QuotaSink (soft periodic target)"]
+        S1["Sink 1<br/>quota, over/under penalty"]
+        S2["Sink 2<br/>..."]
+    end
+    F1 --> M
+    F2 --> M
+    F3 --> M
+    M --> S1
+    M --> S2
+```
+
+That's the whole generalization: swap what `value_function`/`feasible_duration`/`duration_penalty`
+compute, and the same model that schedules poultry flocks schedules cheese wheels, wine barrels,
+or produce lots with a hard shelf life:
+
+| Generic construct | Poultry | Cheese aging | Fresh produce (shelf-life) |
+|---|---|---|---|
+| `MaturationSource` | a farm | an aging cave | a packing facility/lot |
+| `value_function(duration)` | weight at age `duration` | moisture/flavor development | constant |
+| `feasible_duration` | within the target weight band | within the aging window | age ≤ shelf life |
+| `duration_penalty` | off-target-weight discount | early/late-release discount | none |
+| `QuotaSink` | a slaughterhouse | a distributor | a retail chain |
+
+Full write-up, both `add_product!` forms (a convenience form for value that rises toward a
+target, and a fully custom form for arbitrary curves), and a worked shelf-life example are in the
+[Maturation Scheduling docs](https://SupplyChef.github.io/SupplyChainOptimization.jl/dev/maturation%20scheduling/).
+
+## Does it actually replicate the paper?
+
+We reconstructed the paper's Section 6.1 instance-generation recipe — capacity and growth-rate
+ranges, weight-band deviation parameters, the delivery calendar, the quota derivation — using
+only the public `MaturationSource`/`QuotaSink`/`create_maturation_scheduling_model` API (no
+poultry-specific code path). Since the paper uses a different random seed (and one part of its
+quota-derivation recipe is reconstructed from prose, not a published formula), this doesn't
+claim to numerically match the paper's own figures. What it does show is a real, solved instance
+(60 farms, 1 slaughterhouse, 6-week horizon) whose cost decomposes exactly like the paper's own
+Figure 2:
+
+| Component | Value |
+|---|---|
+| `OF` (total cost) | 321,661.16 |
+| `OF_d` (transportation) | 303,539.16 |
+| `OF_w` (weight deviation) | 0.00 |
+| `OF_q+` (overproduction) | 257.00 |
+| `OF_q-` (underproduction) | 17,865.00 |
+
+Transportation dominates the total, as you'd expect in a real distribution problem; every
+shipped batch landed inside its acceptable weight band (zero deviation cost); and quota misses
+are a small fraction of total volume shipped. The first version of this replication test was
+actually degenerate — a unit-scaling mistake meant *no* farm ever shipped anything, because a
+bird's transport cost was priced on the same scale as the quota penalty on a grid where
+distances run into the hundreds. Fixing that (and adding a regression test that catches it)
+turned a trivial zero-cost solution into the numbers above.
+
+## Is the matheuristic worth using here?
+
+We also built a generic large-neighborhood-search / RINS-style matheuristic
+(`matheuristic_optimize!`) that works on *any* model this package produces — tested against both
+the maturation-scheduling model above and the package's existing network design model. Honest
+result: on the instance sizes we benchmarked (60 farms/1 sink and 200 farms/3 sinks), it does
+**not** measurably beat HiGHS's own direct solve, because HiGHS proves global optimality quickly
+at those scales — there's no gap left to close. It doesn't regress anything either. Whether it
+helps on genuinely hard instances (larger capacitated facility-location problems, or against a
+commercial solver like Gurobi) is open — see the tracking issue.
+
+## Try it
+
+```julia
+using SupplyChainModeling
+using SupplyChainOptimization
+
+sc = SupplyChain(30)
+bird = Product("bird")
+add_product!(sc, bird)
+
+farm = MaturationSource("Farm A", Location(46.8, -71.2); capacity=10_000, changeover_periods=3)
+add_product!(farm, bird; initial_value=45.0, maturation_rate=60.0, target_value=2250.0,
+                         acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
+                         extended_deviation_under=0.05, extended_deviation_over=0.05,
+                         underrun_unit_penalty=0.001, overrun_unit_penalty=0.001)
+add_maturation_source!(sc, farm)
+
+slaughterhouse = QuotaSink("Slaughterhouse", Location(46.8, -71.2))
+add_product!(slaughterhouse, bird; quota=15_000, underproduction_unit_penalty=1.0, overproduction_unit_penalty=1.0)
+add_quota_sink!(sc, slaughterhouse)
+
+optimize_maturation_schedule!(sc; transport_cost_per_distance=1.0, distance=haversine_km)
+get_maturation_schedule(sc, farm, bird)
+```
+
+- Paper: Gbéya, Darvish, Renaud and Coelho (2026), *"Integrated Poultry Production-Distribution
+  Optimization,"* CIRRELT-2026-10.
+- Docs: [Maturation Scheduling](https://SupplyChef.github.io/SupplyChainOptimization.jl/dev/maturation%20scheduling/) · [Matheuristics](https://SupplyChef.github.io/SupplyChainOptimization.jl/dev/matheuristics/)
+- Code: [SupplyChainModeling.jl](https://github.com/SupplyChef/SupplyChainModeling.jl) (node types) · [SupplyChainOptimization.jl](https://github.com/SupplyChef/SupplyChainOptimization.jl) (model + matheuristic)

--- a/Project.toml
+++ b/Project.toml
@@ -26,14 +26,5 @@ StatsBase = "0.34"
 SupplyChainModeling = "0.2, 0.3, 0.4"
 julia = "1.10"
 
-# TEMPORARY: this branch's MaturationScheduling.jl depends on MaturationSource/QuotaSink,
-# which live on SupplyChainModeling's claude/cirrelt-2026-poultry-m1z7fv branch (version
-# 0.4.0), not yet merged to main or published to a registry. Pointing at that branch here so
-# CI on this PR can resolve and test against it. Once SupplyChainModeling's PR merges to main
-# (and ideally is registry-published), switch this back to `rev = "main"` (matching the
-# pre-existing pattern this section replaced) or drop [sources] entirely - and keep the compat
-# bound above in sync with whatever version is actually resolved, or [sources]-based
-# resolution fails outright (the resolved version must satisfy the compat bound; unlike a
-# plain `Pkg.add(rev=...)`, [sources] does not bypass compat checking).
 [sources]
-SupplyChainModeling = {url = "https://github.com/SupplyChef/SupplyChainModeling.jl", rev = "claude/cirrelt-2026-poultry-m1z7fv"}
+SupplyChainModeling = {url = "https://github.com/SupplyChef/SupplyChainModeling.jl", rev = "main"}

--- a/Project.toml
+++ b/Project.toml
@@ -23,16 +23,17 @@ PlotlyJS = "0.18"
 Plots = "1.40"
 Statistics = "1.10"
 StatsBase = "0.34"
-SupplyChainModeling = "0.2, 0.3"
+SupplyChainModeling = "0.2, 0.3, 0.4"
 julia = "1.10"
 
-# TEMPORARY: the maximum_units/overflow_unit_cost support this depends on has
-# already merged to SupplyChainModeling's main (now at 0.3.1), but isn't
-# published to a registry yet, so point at main directly rather than a moving
-# feature branch. Remove this section once a registry release exists - and
-# keep the compat bound above in sync with whatever version main currently
-# declares in the meantime, or [sources]-based resolution fails outright
-# (main's declared version must satisfy this bound; unlike a plain
-# `Pkg.add(rev=...)`, [sources] does not bypass compat checking).
+# TEMPORARY: this branch's MaturationScheduling.jl depends on MaturationSource/QuotaSink,
+# which live on SupplyChainModeling's claude/cirrelt-2026-poultry-m1z7fv branch (version
+# 0.4.0), not yet merged to main or published to a registry. Pointing at that branch here so
+# CI on this PR can resolve and test against it. Once SupplyChainModeling's PR merges to main
+# (and ideally is registry-published), switch this back to `rev = "main"` (matching the
+# pre-existing pattern this section replaced) or drop [sources] entirely - and keep the compat
+# bound above in sync with whatever version is actually resolved, or [sources]-based
+# resolution fails outright (the resolved version must satisfy the compat bound; unlike a
+# plain `Pkg.add(rev=...)`, [sources] does not bypass compat checking).
 [sources]
-SupplyChainModeling = {url = "https://github.com/SupplyChef/SupplyChainModeling.jl", rev = "main"}
+SupplyChainModeling = {url = "https://github.com/SupplyChef/SupplyChainModeling.jl", rev = "claude/cirrelt-2026-poultry-m1z7fv"}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ SupplyChainOptimization.jl is a package for modeling and optimizing supply chain
 Use built-in constructs to easily model your supply chain and use powerful solvers to optimize it.
 
 Learn more by reading the [documentation](https://SupplyChef.github.io/SupplyChainOptimization.jl/dev).
+
+**New:** [Maturation scheduling](https://SupplyChef.github.io/SupplyChainOptimization.jl/dev/maturation%20scheduling/) models any supply chain where a batch's *value* grows while it's held — poultry
+weight, cheese aging, wine maturation — and must be shipped to meet a periodic delivery quota. See the
+[case study](CASE_STUDY.md) for a worked example replicating a published academic model.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(
     modules = [SupplyChainOptimization],
     checkdocs = :exports, # every exported symbol must have a docstring, and only exported symbols may be @docs'd - see docs/src/reference.md
     pages = ["index.md",
-            "Examples" => ["optimization flows.md", "optimization locations.md", "multi-period optimization.md", "adding special constraints.md", "inventory movements.md"],
+            "Examples" => ["optimization flows.md", "optimization locations.md", "multi-period optimization.md", "adding special constraints.md", "inventory movements.md", "maturation scheduling.md"],
             "Internals" => ["optimization model.md"],
             "API" => ["reference.md"],
             "Sponsor" => ["sponsor.md"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,7 +20,7 @@ makedocs(
     modules = [SupplyChainOptimization],
     checkdocs = :exports, # every exported symbol must have a docstring, and only exported symbols may be @docs'd - see docs/src/reference.md
     pages = ["index.md",
-            "Examples" => ["optimization flows.md", "optimization locations.md", "multi-period optimization.md", "adding special constraints.md", "inventory movements.md", "maturation scheduling.md"],
+            "Examples" => ["optimization flows.md", "optimization locations.md", "multi-period optimization.md", "adding special constraints.md", "inventory movements.md", "maturation scheduling.md", "matheuristics.md"],
             "Internals" => ["optimization model.md"],
             "API" => ["reference.md"],
             "Sponsor" => ["sponsor.md"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,13 +3,12 @@ Pkg.add("CSV")
 Pkg.add("DataFrames")
 Pkg.add("JuMP")
 Pkg.add("HiGHS")
-# TEMPORARY: docs/ is a separate Pkg environment from the package root, so the root
-# Project.toml's [sources] override (see the comment there) isn't inherited here - a plain
-# Pkg.add("SupplyChainModeling") resolves the registry's latest release (0.2.8), which predates
-# MaturationSource/QuotaSink, and the doctest/makedocs build below fails to precompile without
-# them. Pin explicitly here too, and revert alongside the other two spots (Project.toml
-# [sources], .github/workflows/ci.yml) once the companion SupplyChainModeling PR merges.
-Pkg.add(url="https://github.com/SupplyChef/SupplyChainModeling.jl", rev="claude/cirrelt-2026-poultry-m1z7fv")
+# docs/ is a separate Pkg environment from the package root, so the root Project.toml's
+# [sources] override (see the comment there) isn't inherited here - a plain
+# Pkg.add("SupplyChainModeling") resolves the registry's latest release (0.2.8, stale relative
+# to main), so it's pinned to the git source explicitly here too, matching
+# .github/workflows/ci.yml.
+Pkg.add(url="https://github.com/SupplyChef/SupplyChainModeling.jl", rev="main")
 
 using Documenter
 using SupplyChainOptimization

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,15 @@
-import Pkg; 
+import Pkg;
 Pkg.add("CSV")
 Pkg.add("DataFrames")
 Pkg.add("JuMP")
 Pkg.add("HiGHS")
-Pkg.add("SupplyChainModeling")
+# TEMPORARY: docs/ is a separate Pkg environment from the package root, so the root
+# Project.toml's [sources] override (see the comment there) isn't inherited here - a plain
+# Pkg.add("SupplyChainModeling") resolves the registry's latest release (0.2.8), which predates
+# MaturationSource/QuotaSink, and the doctest/makedocs build below fails to precompile without
+# them. Pin explicitly here too, and revert alongside the other two spots (Project.toml
+# [sources], .github/workflows/ci.yml) once the companion SupplyChainModeling PR merges.
+Pkg.add(url="https://github.com/SupplyChef/SupplyChainModeling.jl", rev="claude/cirrelt-2026-poultry-m1z7fv")
 
 using Documenter
 using SupplyChainOptimization

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,6 +2,14 @@
 
 SupplyChainOptimization.jl is a package for modeling and optimizing supply chains.
 
+!!! note "New: Maturation scheduling"
+    Model supply chains where a batch's *value* grows while it's held and must ship to meet a
+    periodic delivery quota — poultry weight, cheese aging, wine maturation, or classical
+    shelf-life inventory are all the same underlying problem. See
+    [Maturation Scheduling](@ref) and [Matheuristics](@ref), or the
+    [case study](https://github.com/SupplyChef/SupplyChainOptimization.jl/blob/main/CASE_STUDY.md)
+    replicating a published production-distribution model end to end.
+
 ## Installation
 
 SupplyChainOptimization can be installed using the Julia package manager.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@ SupplyChainOptimization.jl is a package for modeling and optimizing supply chain
     Model supply chains where a batch's *value* grows while it's held and must ship to meet a
     periodic delivery quota — poultry weight, cheese aging, wine maturation, or classical
     shelf-life inventory are all the same underlying problem. See
-    [Maturation Scheduling](@ref) and [Matheuristics](@ref), or the
+    [`create_maturation_scheduling_model`](@ref) and [`matheuristic_optimize!`](@ref), or the
     [case study](https://github.com/SupplyChef/SupplyChainOptimization.jl/blob/main/CASE_STUDY.md)
     replicating a published production-distribution model end to end.
 

--- a/docs/src/matheuristics.md
+++ b/docs/src/matheuristics.md
@@ -1,0 +1,50 @@
+# Matheuristics
+
+Large, real-world instances of either [`minimize_cost!`](@ref)/[`maximize_profits!`](@ref)'s
+network design problem or [`create_maturation_scheduling_model`](@ref)'s scheduling problem can
+be too slow to solve to proven optimality directly. [`matheuristic_optimize!`](@ref) is a
+generic large-neighborhood-search matheuristic that works on *any* solved JuMP model - it
+repeatedly pins most integer/binary variables to their current best values, re-optimizes the
+rest, and keeps any improvement.
+
+```julia
+using SupplyChainModeling
+using SupplyChainOptimization
+
+sc = SupplyChain(1)
+
+product = Product("Product 1")
+add_product!(sc, product)
+
+customer = Customer("Customer 1", Location(47.6, -122.3))
+add_customer!(sc, customer)
+add_demand!(sc, customer, product, [100.0])
+
+storage = Storage("Storage 1", Location(47.6, -122.3); fixed_cost=1000.0, initial_opened=true)
+add_product!(storage, product; initial_inventory=100.0)
+add_storage!(sc, storage)
+
+add_lane!(sc, Lane(storage, customer; unit_cost=1.0))
+
+minimize_cost!(sc; time_limit=30.0)  # a first, possibly time-limited solve
+
+matheuristic_optimize!(sc.optimization_model; iterations=200, fix_fraction=0.9)
+
+get_total_costs(sc)
+```
+
+It applies equally to the maturation-scheduling model:
+
+```julia
+m = create_maturation_scheduling_model(sc; transport_cost_per_distance=1.0)
+JuMP.optimize!(m)
+matheuristic_optimize!(m; iterations=200, neighborhood=:local_branching, local_branching_k=20)
+```
+
+This is a model-agnostic default, not a replacement for a problem-aware heuristic: it has no
+idea what a `y` or `r` variable means, only that some of them are integer/binary. A hand-tuned,
+domain-aware neighborhood - like the clustering-and-relatedness matheuristic in the IPPDP paper
+this package's maturation-scheduling model is based on (Gbéya, Darvish, Renaud and Coelho (2026),
+CIRRELT-2026-10) - will typically still beat this on any one problem. Reach for
+[`matheuristic_optimize!`](@ref) as a solid starting point on a large instance, or when writing a
+problem-specific search isn't (yet) worth the investment.

--- a/docs/src/maturation scheduling.md
+++ b/docs/src/maturation scheduling.md
@@ -61,8 +61,20 @@ end
 
 ## Generalizing beyond poultry
 
-Nothing in `MaturationSource` or `QuotaSink` is poultry-specific - `capacity`,
-`maturation_rate`, `target_value` and the acceptable/extended deviation bands describe any batch
-whose value grows linearly while held, and `quota`/`underproduction_unit_penalty`/
-`overproduction_unit_penalty` describe any soft periodic delivery target. The same model applies
-to livestock finishing, aging/curing processes, or contractual delivery commitments more broadly.
+Nothing in `MaturationSource` or `QuotaSink` is poultry-specific, and nothing about the batch's
+value even has to *grow*. `MaturationSource`'s `add_product!` has two forms: a convenience form
+(`capacity`, `maturation_rate`, `target_value`, acceptable/extended deviation bands) for the
+common case of value rising linearly toward a target - the shape this poultry example, aging
+cheese, or a distillery barrel all share - and a fully custom form taking arbitrary
+`value_function`/`feasible_duration`/`duration_penalty` functions of duration.
+
+That custom form is what lets `MaturationSource` also express classical perishable/shelf-life
+inventory (constant value, unsellable past a fixed age) rather than just harvest-scheduling-style
+curves - the two families of problems the operations-research literature usually treats
+separately turn out to be the same object with a different curve shape. See
+`MaturationSource`'s own docstring for the literature connection, and its `add_product!`
+docstring for a shelf-life example.
+
+`QuotaSink`'s `quota`/`underproduction_unit_penalty`/`overproduction_unit_penalty` describe any
+soft periodic delivery target - a supply-managed quota, a contractual minimum order commitment,
+or any other target a business would rather miss (at a cost) than treat as a hard constraint.

--- a/docs/src/maturation scheduling.md
+++ b/docs/src/maturation scheduling.md
@@ -68,13 +68,60 @@ common case of value rising linearly toward a target - the shape this poultry ex
 cheese, or a distillery barrel all share - and a fully custom form taking arbitrary
 `value_function`/`feasible_duration`/`duration_penalty` functions of duration.
 
+Mapping your own problem onto these constructs is a matter of naming, not modeling:
+
+| Generic construct | Poultry (this example) | Cheese aging | Fresh produce (shelf-life) |
+|---|---|---|---|
+| `MaturationSource` | a farm | an aging cave | a packing facility/lot |
+| `capacity` | birds per flock | wheels per batch | units per harvest lot |
+| `value_function(duration)` | weight at age `duration` | moisture/flavor development | constant (see below) |
+| `feasible_duration` | within the target weight band | within the aging window | age ≤ shelf life |
+| `duration_penalty` | off-target-weight discount | early/late-release discount | none (either sellable or not) |
+| `changeover_periods` | biosecurity sanitation | barrel/cave cleaning | lot changeover |
+| `QuotaSink` | a slaughterhouse | a distributor | a retail chain |
+| `quota` | daily bird intake target | weekly case commitment | weekly order commitment |
+
 That custom form is what lets `MaturationSource` also express classical perishable/shelf-life
 inventory (constant value, unsellable past a fixed age) rather than just harvest-scheduling-style
 curves - the two families of problems the operations-research literature usually treats
 separately turn out to be the same object with a different curve shape. See
-`MaturationSource`'s own docstring for the literature connection, and its `add_product!`
-docstring for a shelf-life example.
+`MaturationSource`'s own docstring for the literature connection.
 
 `QuotaSink`'s `quota`/`underproduction_unit_penalty`/`overproduction_unit_penalty` describe any
 soft periodic delivery target - a supply-managed quota, a contractual minimum order commitment,
 or any other target a business would rather miss (at a cost) than treat as a hard constraint.
+
+## A second example: classical shelf-life inventory, not harvest scheduling
+
+A produce packer holds lots that are simply sellable or not - full value for 5 days after
+packing, worthless after - and ships to a single retail chain with a weekly order commitment.
+This is the custom-curve form of `add_product!`, and it needs no weight/growth concepts at all:
+
+```julia
+using SupplyChainModeling
+using SupplyChainOptimization
+
+sc = SupplyChain(30)
+
+produce = Product("berries")
+add_product!(sc, produce)
+
+lot = MaturationSource("Packing Lot 1", Location(44.6, -63.6); capacity=2_000)
+add_product!(lot, produce,
+             duration -> 1.0,               # value_function: full value throughout shelf life
+             duration -> duration <= 5,      # feasible_duration: sellable for 5 days, then not
+             duration -> 0.0)                # duration_penalty: no partial-quality discount
+add_maturation_source!(sc, lot)
+
+retailer = QuotaSink("Retail Chain", Location(44.65, -63.57))
+add_product!(retailer, produce; quota=2_000, underproduction_unit_penalty=5.0, overproduction_unit_penalty=1.0)
+add_quota_sink!(sc, retailer)
+
+optimize_maturation_schedule!(sc; transport_cost_per_distance=2.0, distance=haversine_km)
+
+get_maturation_schedule(sc, lot, produce)
+```
+
+Underproduction is penalized more heavily than overproduction here (`5.0` vs `1.0`) since an
+empty shelf loses a sale outright while excess stock is merely a markdown - the same
+`QuotaSink` fields, just weighted for a different business reality than the poultry example's.

--- a/docs/src/maturation scheduling.md
+++ b/docs/src/maturation scheduling.md
@@ -8,10 +8,11 @@ off against a quality/weight target and against a delivery commitment (a quota) 
 end.
 
 [`create_maturation_scheduling_model`](@ref) solves this problem: given a set of
-[`MaturationSource`](@ref)s (each holding at most one batch per planning horizon, "all-in-all-out")
-and a set of [`QuotaSink`](@ref)s (each with a soft periodic delivery target), it chooses each
+`MaturationSource`s (each holding at most one batch per planning horizon, "all-in-all-out")
+and a set of `QuotaSink`s (each with a soft periodic delivery target), it chooses each
 source's start day, ship day, and destination sink to minimize transportation cost, value-deviation
-penalties, and quota-deviation penalties.
+penalties, and quota-deviation penalties. Both types are defined in
+[SupplyChainModeling.jl](https://SupplyChef.github.io/SupplyChainModeling.jl/dev).
 
 This generalizes the integrated poultry production-distribution problem (IPPDP) of Gbéya, Darvish,
 Renaud and Coelho (2026), "Integrated Poultry Production-Distribution Optimization", CIRRELT-2026-10.
@@ -60,7 +61,7 @@ end
 
 ## Generalizing beyond poultry
 
-Nothing in [`MaturationSource`](@ref) or [`QuotaSink`](@ref) is poultry-specific - `capacity`,
+Nothing in `MaturationSource` or `QuotaSink` is poultry-specific - `capacity`,
 `maturation_rate`, `target_value` and the acceptable/extended deviation bands describe any batch
 whose value grows linearly while held, and `quota`/`underproduction_unit_penalty`/
 `overproduction_unit_penalty` describe any soft periodic delivery target. The same model applies

--- a/docs/src/maturation scheduling.md
+++ b/docs/src/maturation scheduling.md
@@ -1,0 +1,67 @@
+# Maturation Scheduling
+
+Some supply chains don't move a fixed product between fixed-lead-time nodes - they *grow* it.
+A poultry farm holds chicks until they reach a target slaughter weight; a cheesemaker holds
+wheels until they reach a target age; a distillery holds barrels until the spirit reaches a
+target proof. In each case, how long you hold the batch is itself a decision, one that trades
+off against a quality/weight target and against a delivery commitment (a quota) at the other
+end.
+
+[`create_maturation_scheduling_model`](@ref) solves this problem: given a set of
+[`MaturationSource`](@ref)s (each holding at most one batch per planning horizon, "all-in-all-out")
+and a set of [`QuotaSink`](@ref)s (each with a soft periodic delivery target), it chooses each
+source's start day, ship day, and destination sink to minimize transportation cost, value-deviation
+penalties, and quota-deviation penalties.
+
+This generalizes the integrated poultry production-distribution problem (IPPDP) of Gbéya, Darvish,
+Renaud and Coelho (2026), "Integrated Poultry Production-Distribution Optimization", CIRRELT-2026-10.
+
+## Example
+
+Two farms feed a single slaughterhouse with a daily quota. Each farm can only ship once per
+horizon, and birds must ship within a target weight band or be sold at a penalty to an
+alternative market.
+
+```julia
+using SupplyChainModeling
+using SupplyChainOptimization
+
+sc = SupplyChain(30)
+
+bird = Product("bird")
+add_product!(sc, bird)
+
+for (name, location) in [("Farm A", Location(46.8, -71.2)), ("Farm B", Location(46.5, -71.9))]
+    farm = MaturationSource(name, location; capacity=10_000, changeover_periods=3)
+    add_product!(farm, bird; initial_value=45.0, maturation_rate=60.0, target_value=2250.0,
+                             acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
+                             extended_deviation_under=0.05, extended_deviation_over=0.05,
+                             underrun_unit_penalty=0.001, overrun_unit_penalty=0.001)
+    add_maturation_source!(sc, farm)
+end
+
+slaughterhouse = QuotaSink("Slaughterhouse", Location(46.8, -71.2))
+add_product!(slaughterhouse, bird; quota=15_000, underproduction_unit_penalty=1.0, overproduction_unit_penalty=1.0)
+add_quota_sink!(sc, slaughterhouse)
+
+# Hatcheries typically don't deliver on Wednesdays, Saturdays or Sundays, and slaughterhouses
+# don't run on weekends - is_start_day/is_delivery_day encode that without touching the model.
+is_weekday_except_wednesday(t) = !(t % 7 in (0, 3, 4))
+is_weekday(t) = !(t % 7 in (0, 1))
+
+optimize_maturation_schedule!(sc; transport_cost_per_distance=1.0, distance=haversine_km,
+                              is_start_day=is_weekday_except_wednesday, is_delivery_day=is_weekday)
+
+for farm in sc.maturation_sources
+    schedule = get_maturation_schedule(sc, farm, bird)
+    println("$farm: starts day $(schedule.start_day), ships day $(schedule.ship_day) to $(schedule.sink)")
+end
+```
+
+## Generalizing beyond poultry
+
+Nothing in [`MaturationSource`](@ref) or [`QuotaSink`](@ref) is poultry-specific - `capacity`,
+`maturation_rate`, `target_value` and the acceptable/extended deviation bands describe any batch
+whose value grows linearly while held, and `quota`/`underproduction_unit_penalty`/
+`overproduction_unit_penalty` describe any soft periodic delivery target. The same model applies
+to livestock finishing, aging/curing processes, or contractual delivery commitments more broadly.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -25,6 +25,12 @@ get_quota_shortfall
 get_quota_excess
 ```
 
+## Matheuristics
+
+```@docs
+matheuristic_optimize!
+```
+
 ## Querying Results
 
 ```@docs

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -12,6 +12,17 @@ SupplyChainOptimization.create_network_profit_maximization_model!
 SupplyChainOptimization.optimize_network_optimization_model!
 SupplyChainOptimization.create_network_model
 haversine
+haversine_km
+```
+
+## Maturation Scheduling (IPPDP)
+
+```@docs
+create_maturation_scheduling_model
+optimize_maturation_schedule!
+get_maturation_schedule
+get_quota_shortfall
+get_quota_excess
 ```
 
 ## Querying Results

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -23,6 +23,10 @@ optimize_maturation_schedule!
 get_maturation_schedule
 get_quota_shortfall
 get_quota_excess
+get_total_deviation_costs
+get_total_overproduction_costs
+get_total_underproduction_costs
+get_total_quota_deviation_costs
 ```
 
 ## Matheuristics

--- a/src/Matheuristics.jl
+++ b/src/Matheuristics.jl
@@ -175,6 +175,11 @@ function matheuristic_optimize!(model; iterations::Int=10, fix_fraction::Real=0.
         end
     end
 
+    # Restore every variable's bounds *before* the final solve below, not after: JuMP marks a
+    # model "modified since last optimize!" the moment a bound changes, which invalidates the
+    # cached solution - restoring bounds after the final optimize! would leave has_values/
+    # objective_value/value unusable (OptimizeNotCalled()) for the caller. Restoring first and
+    # solving last means this function's very last model-touching action is optimize! itself.
     for v in discrete_vars
         _restore_bounds!(v, original_bounds[v])
     end
@@ -182,15 +187,13 @@ function matheuristic_optimize!(model; iterations::Int=10, fix_fraction::Real=0.
         delete(model, local_branching_constraint)
     end
 
-    # Leave model solved at the best solution found, with every variable's own bounds back to
-    # what they were originally (the pinning above is not left in place).
-    for v in discrete_vars
-        _pin!(v, best_values[v])
+    # Original bounds are always a relaxation of whatever was pinned during the search, so
+    # best_values remains feasible here - warm-starting from it means this final solve can only
+    # match or improve on best_objective, never regress, even under a tight time limit.
+    for v in all_vars
+        set_start_value(v, best_values[v])
     end
     JuMP.optimize!(model)
-    for v in discrete_vars
-        _restore_bounds!(v, original_bounds[v])
-    end
 
     return model
 end

--- a/src/Matheuristics.jl
+++ b/src/Matheuristics.jl
@@ -98,14 +98,37 @@ support that attribute name) - since each iteration only needs *a* feasible, hop
 solution, not a proof of optimality, bounding how long any single iteration can run keeps the
 overall search moving instead of stalling on one hard sub-problem.
 
+Every iteration's sub-solve, including the final one, is warm-started from the best solution
+found so far via `JuMP.set_start_value` - `model`'s current incumbent is always feasible for
+whatever neighborhood the next iteration explores, so this costs nothing and generally speeds up
+each re-solve.
+
 `model` is left, on return, re-solved at the best solution found (with every variable's bounds
 restored to what they were before this function was called - the pinning done internally is not
-left in place).
+left in place), and still warm-started at that solution. That means a caller can use this
+function to warm-start a subsequent, longer or exact solve: call `matheuristic_optimize!` with a
+modest iteration/time budget first, then call `JuMP.optimize!(model)` again directly (optionally
+after raising `"time_limit"` or removing it) - the solver picks up the existing start values
+(a JuMP model attribute that persists across `optimize!` calls, not cleared automatically) as its
+initial incumbent, typically pruning the search tree faster than starting cold.
 """
 function matheuristic_optimize!(model; iterations::Int=10, fix_fraction::Real=0.8, neighborhood::Symbol=:fix,
                                 local_branching_k::Int=20, time_limit_per_iteration::Union{Nothing, Real}=nothing)
     neighborhood in (:fix, :local_branching) || throw(ArgumentError("matheuristic_optimize!: neighborhood must be :fix or :local_branching, got $(repr(neighborhood))"))
     0.0 <= fix_fraction <= 1.0 || throw(ArgumentError("matheuristic_optimize!: fix_fraction must be between 0 and 1, got $fix_fraction"))
+
+    # Applied before the very first solve below, not just subsequent iterations' - otherwise an
+    # unsolved model handed in with no prior time limit of its own would run that first solve to
+    # completion with no bound at all, defeating the purpose of a time-boxed search on a hard
+    # instance.
+    if !isnothing(time_limit_per_iteration)
+        try
+            set_attribute(model, "time_limit", Float64(time_limit_per_iteration))
+        catch
+            # Best-effort: not every solver exposes a "time_limit" string attribute. Falling
+            # back to running each solve to completion is safe, just potentially slower.
+        end
+    end
 
     if !has_values(model)
         JuMP.optimize!(model)
@@ -128,15 +151,6 @@ function matheuristic_optimize!(model; iterations::Int=10, fix_fraction::Real=0.
 
     best_objective = objective_value(model)
     best_values = Dict(v => value(v) for v in all_vars)
-
-    if !isnothing(time_limit_per_iteration)
-        try
-            set_attribute(model, "time_limit", Float64(time_limit_per_iteration))
-        catch
-            # Best-effort: not every solver exposes a "time_limit" string attribute. Falling
-            # back to running each iteration to completion is safe, just potentially slower.
-        end
-    end
 
     local_branching_constraint = nothing
     use_local_branching = neighborhood == :local_branching && !isempty(binary_vars)
@@ -162,6 +176,13 @@ function matheuristic_optimize!(model; iterations::Int=10, fix_fraction::Real=0.
             end
         end
 
+        # Warm-start every iteration's sub-solve from the current incumbent, not just the final
+        # solve below - best_values is always feasible for this iteration's (relaxed or
+        # partially-fixed) neighborhood, so the solver starts from a known-good point instead of
+        # rediscovering one, on every iteration, not only the last.
+        for v in all_vars
+            set_start_value(v, best_values[v])
+        end
         JuMP.optimize!(model)
 
         if has_values(model)

--- a/src/Matheuristics.jl
+++ b/src/Matheuristics.jl
@@ -1,0 +1,196 @@
+# Captures enough of a variable's original bound state to restore it exactly later.
+# JuMP.fix(x, v; force=true) permanently discards any pre-existing bounds, and JuMP.unfix does
+# not restore them - deliberately avoided here in favor of directly saving/restoring
+# lower_bound/upper_bound (or their absence), so a variable that started unbounded above (like
+# an Int >= 0 variable with no explicit upper bound) ends up unbounded above again, not stuck
+# at whatever bound pinning last set.
+struct _VariableBounds
+    has_lower::Bool
+    lower::Float64
+    has_upper::Bool
+    upper::Float64
+end
+
+function _capture_bounds(v)
+    has_lower = has_lower_bound(v)
+    has_upper = has_upper_bound(v)
+    return _VariableBounds(has_lower, has_lower ? lower_bound(v) : -Inf, has_upper, has_upper ? upper_bound(v) : Inf)
+end
+
+function _restore_bounds!(v, bounds::_VariableBounds)
+    if bounds.has_lower
+        set_lower_bound(v, bounds.lower)
+    elseif has_lower_bound(v)
+        delete_lower_bound(v)
+    end
+    if bounds.has_upper
+        set_upper_bound(v, bounds.upper)
+    elseif has_upper_bound(v)
+        delete_upper_bound(v)
+    end
+end
+
+# Pins a variable to a single value by tightening both bounds to it, rather than JuMP.fix (see
+# _VariableBounds above for why). Rounds first: an incumbent binary/integer value read back
+# from a solver is occasionally e.g. 0.999999997 rather than exactly 1.0, which would otherwise
+# pin against the variable's own binary/integer domain by a hair and risk a spurious
+# infeasibility.
+function _pin!(v, value)
+    rounded = round(value)
+    set_lower_bound(v, rounded)
+    set_upper_bound(v, rounded)
+end
+
+# Picks n elements of collection at random, without replacement, using Base's global RNG (via
+# plain rand(1:n) - no `using Random` needed, matching how SupplyChainSimulation.jl's own
+# bboptimize does its own random search without importing Random either).
+function _random_sample(collection, n)
+    pool = collect(collection)
+    n = min(n, length(pool))
+    selected = eltype(pool)[]
+    for _ in 1:n
+        index = rand(1:length(pool))
+        push!(selected, pool[index])
+        deleteat!(pool, index)
+    end
+    return selected
+end
+
+"""
+    matheuristic_optimize!(model::JuMP.Model; iterations=10, fix_fraction=0.8, neighborhood=:fix,
+                           local_branching_k=20, time_limit_per_iteration=nothing)
+
+A model-agnostic large-neighborhood-search matheuristic for MILP models built with JuMP.
+Repeatedly destroys part of the current incumbent solution and re-solves the reduced problem,
+keeping any improvement - large real-world MILPs (like [`minimize_cost!`](@ref)/
+[`maximize_profits!`](@ref)'s network design problem, or
+[`create_maturation_scheduling_model`](@ref)'s scheduling problem) can be too slow to solve to
+proven optimality directly, but re-solving with most of the incumbent held fixed is typically
+fast, and repeating this thousands of times finds much better solutions than stopping the direct
+solve early.
+
+Unlike a problem-specific matheuristic (e.g. the IPPDP paper this package's maturation-scheduling
+model is based on uses a domain-aware clustering construction plus Shaw-relatedness removal
+operators - see Gbéya, Darvish, Renaud and Coelho (2026), CIRRELT-2026-10), this function only
+looks at `model`'s variables and their current values: it works on *any* JuMP model that already
+has a feasible solution, with zero knowledge of what the variables mean. That genericity is also
+its ceiling - a hand-tuned, problem-aware neighborhood (like the paper's) will typically still
+beat this on any one problem; this is meant as a solid, reusable default, not a replacement for
+one.
+
+`model` must already have (or be able to find, via an initial `JuMP.optimize!` if it hasn't been
+solved yet) at least one feasible solution - there is nothing to build a neighborhood *around*
+otherwise. If `model` has no integer/binary variables at all, or no feasible solution can be
+found, `model` is returned unchanged.
+
+Two neighborhoods are available via `neighborhood`:
+- `:fix` (the default, a RINS-style destroy operator): each iteration, a random
+  `fix_fraction` of the integer/binary variables are pinned to their best-known values and the
+  rest are re-optimized freely.
+- `:local_branching` (Fischetti and Lodi, 2003): each iteration restricts the solution to
+  differ from the best-known one in at most `local_branching_k` binary variables (a Hamming-ball
+  neighborhood), leaving every variable itself free to move. Falls back to `:fix` if `model` has
+  no binary variables (local branching's flip-counting constraint only applies to those).
+
+`time_limit_per_iteration`, if given, is applied as a best-effort `"time_limit"` solver
+attribute before each iteration's re-solve (silently ignored if the underlying solver doesn't
+support that attribute name) - since each iteration only needs *a* feasible, hopefully-improving
+solution, not a proof of optimality, bounding how long any single iteration can run keeps the
+overall search moving instead of stalling on one hard sub-problem.
+
+`model` is left, on return, re-solved at the best solution found (with every variable's bounds
+restored to what they were before this function was called - the pinning done internally is not
+left in place).
+"""
+function matheuristic_optimize!(model; iterations::Int=10, fix_fraction::Real=0.8, neighborhood::Symbol=:fix,
+                                local_branching_k::Int=20, time_limit_per_iteration::Union{Nothing, Real}=nothing)
+    neighborhood in (:fix, :local_branching) || throw(ArgumentError("matheuristic_optimize!: neighborhood must be :fix or :local_branching, got $(repr(neighborhood))"))
+    0.0 <= fix_fraction <= 1.0 || throw(ArgumentError("matheuristic_optimize!: fix_fraction must be between 0 and 1, got $fix_fraction"))
+
+    if !has_values(model)
+        JuMP.optimize!(model)
+    end
+    if !has_values(model)
+        return model
+    end
+
+    all_vars = JuMP.all_variables(model)
+    discrete_vars = [v for v in all_vars if is_binary(v) || is_integer(v)]
+    if isempty(discrete_vars)
+        return model
+    end
+    binary_vars = [v for v in discrete_vars if is_binary(v)]
+
+    original_bounds = Dict(v => _capture_bounds(v) for v in discrete_vars)
+
+    is_minimization = objective_sense(model) == JuMP.MOI.MIN_SENSE
+    improves(new_value, old_value) = is_minimization ? new_value < old_value : new_value > old_value
+
+    best_objective = objective_value(model)
+    best_values = Dict(v => value(v) for v in all_vars)
+
+    if !isnothing(time_limit_per_iteration)
+        try
+            set_attribute(model, "time_limit", Float64(time_limit_per_iteration))
+        catch
+            # Best-effort: not every solver exposes a "time_limit" string attribute. Falling
+            # back to running each iteration to completion is safe, just potentially slower.
+        end
+    end
+
+    local_branching_constraint = nothing
+    use_local_branching = neighborhood == :local_branching && !isempty(binary_vars)
+
+    for _ in 1:iterations
+        for v in discrete_vars
+            _restore_bounds!(v, original_bounds[v])
+        end
+        if !isnothing(local_branching_constraint)
+            delete(model, local_branching_constraint)
+            local_branching_constraint = nothing
+        end
+
+        if use_local_branching
+            ones = [v for v in binary_vars if best_values[v] > 0.5]
+            zeros = [v for v in binary_vars if best_values[v] <= 0.5]
+            local_branching_constraint = @constraint(model,
+                sum(1 - v for v in ones; init=0.0) + sum(v for v in zeros; init=0.0) <= local_branching_k)
+        else
+            n_fix = round(Int, fix_fraction * length(discrete_vars))
+            for v in _random_sample(discrete_vars, n_fix)
+                _pin!(v, best_values[v])
+            end
+        end
+
+        JuMP.optimize!(model)
+
+        if has_values(model)
+            candidate_objective = objective_value(model)
+            if improves(candidate_objective, best_objective)
+                best_objective = candidate_objective
+                for v in all_vars
+                    best_values[v] = value(v)
+                end
+            end
+        end
+    end
+
+    for v in discrete_vars
+        _restore_bounds!(v, original_bounds[v])
+    end
+    if !isnothing(local_branching_constraint)
+        delete(model, local_branching_constraint)
+    end
+
+    # Leave model solved at the best solution found, with every variable's own bounds back to
+    # what they were originally (the pinning above is not left in place).
+    for v in discrete_vars
+        _pin!(v, best_values[v])
+    end
+    JuMP.optimize!(model)
+    for v in discrete_vars
+        _restore_bounds!(v, original_bounds[v])
+    end
+
+    return model
+end

--- a/src/MaturationScheduling.jl
+++ b/src/MaturationScheduling.jl
@@ -1,0 +1,215 @@
+"""
+Checks that every product referenced by a `MaturationSource` or `QuotaSink` is registered on
+the supply chain, mirroring `check_model`'s checks for plants/customers.
+"""
+function check_maturation_model(supply_chain)
+    for source in supply_chain.maturation_sources
+        for product in keys(source.initial_value)
+            if !(product in supply_chain.products)
+                throw(ArgumentError("MaturationSource $source has product $product that is not in the supply chain's products."))
+            end
+        end
+    end
+    for sink in supply_chain.quota_sinks
+        for product in keys(sink.quota)
+            if !(product in supply_chain.products)
+                throw(ArgumentError("QuotaSink $sink has product $product that is not in the supply chain's products."))
+            end
+        end
+    end
+end
+
+# A source may start a new batch of product on day u if u is past its mandatory turnaround
+# (unavailable_periods), OR u is day 1 and the source already holds a batch of product
+# (initial_inventory[product] > 0) - day 1 is then a bookkeeping reference for that
+# in-progress batch (see feasible_exits's docstring in Modeling.jl), not a new scheduling
+# choice, so it is exempt from the turnaround gate.
+function _is_valid_start(source, product, u)
+    return u > source.unavailable_periods || (u == 1 && get(source.initial_inventory, product, 0.0) > 0)
+end
+
+# The per-unit deviation penalty for a batch shipping in a given zone (see maturation_zone):
+# 0 for the ideal zone, underrun_unit_penalty/overrun_unit_penalty for the two sellable-but-
+# off-target zones.
+function _deviation_unit_penalty(source, product, zone)
+    if zone == 1
+        return source.underrun_unit_penalty[product]
+    elseif zone == 2
+        return source.overrun_unit_penalty[product]
+    else
+        return 0.0
+    end
+end
+
+"""
+    create_maturation_scheduling_model(supply_chain, optimizer=HiGHS.Optimizer; transport_cost_per_distance,
+                                       distance=haversine, is_start_day=t -> true, is_delivery_day=t -> true)
+
+Builds the mixed-integer linear program for the integrated maturation-scheduling and
+distribution problem: assigning each `MaturationSource`'s single batch a start day, a ship day
+(among the days its resulting value falls in an acceptable or extended-but-sellable range), and
+a `QuotaSink` destination, minimizing the sum of distance-based transportation cost,
+value-deviation penalties, and quota-deviation penalties.
+
+This is the IPPDP of Gbéya, Darvish, Renaud and Coelho (2026), "Integrated Poultry
+Production-Distribution Optimization", CIRRELT-2026-10, generalized from a single poultry
+product/global target to arbitrary products and per-source targets (see `MaturationSource`
+and `QuotaSink`).
+
+`transport_cost_per_distance` is the cost per unit of `distance` (default [`haversine`](@ref),
+which returns meters - see also [`haversine_km`](@ref)) between a source and a sink, applied
+per unit of the source's shipped batch (`MaturationSource.capacity`).
+
+`is_start_day`/`is_delivery_day` restrict which days of the horizon (`1:supply_chain.horizon`)
+batches may start or ship on respectively - e.g. to exclude weekends/holidays. Both default to
+allowing every day.
+
+Call `JuMP.optimize!` on the returned model (or use [`optimize_maturation_schedule!`](@ref)),
+then query results with [`get_maturation_schedule`](@ref), [`get_quota_shortfall`](@ref) and
+[`get_quota_excess`](@ref).
+"""
+function create_maturation_scheduling_model(supply_chain, optimizer=HiGHS.Optimizer; transport_cost_per_distance::Real,
+                                            distance=haversine, is_start_day=t -> true, is_delivery_day=t -> true)
+    check_maturation_model(supply_chain)
+
+    sources = supply_chain.maturation_sources
+    sinks = supply_chain.quota_sinks
+    products = supply_chain.products
+
+    T = 1:supply_chain.horizon
+    U = [t for t in T if is_start_day(t)]
+    V = [t for t in T if is_delivery_day(t)]
+
+    m = Model(optimizer)
+    set_string_names_on_creation(m, false)
+
+    # Precomputed alongside the (sparse, filtered) @variable containers below, and registered
+    # on the model (m[:y_index]/m[:r_index]) so query functions (get_maturation_schedule) can
+    # iterate the exact set of valid keys as a plain Vector of tuples, rather than relying on
+    # JuMP.Containers.SparseAxisArray's own iteration protocol.
+    y_index = [(b, p, u, t) for b in sources, p in products, u in U, t in V
+               if has_product(b, p) && t > u && _is_valid_start(b, p, u) && !isnothing(maturation_zone(b, p, t - u))]
+    r_index = [(b, p, s, t) for b in sources, p in products, s in sinks, t in V if has_product(b, p)]
+
+    # y[b,p,u,t]: a batch of p starts at source b on day u and ships on day t.
+    @variable(m, y[b=sources, p=products, u=U, t=V;
+                   has_product(b, p) && t > u && _is_valid_start(b, p, u) && !isnothing(maturation_zone(b, p, t - u))], Bin)
+
+    # r[b,p,s,t]: source b's batch of p ships to sink s on day t.
+    @variable(m, r[b=sources, p=products, s=sinks, t=V; has_product(b, p)], Bin)
+
+    # q_plus/q_minus: sink s's over/under-quota deviation for p on day t.
+    @variable(m, q_plus[s=sinks, p=products, t=V; has_product(s, p)] >= 0, Int)
+    @variable(m, q_minus[s=sinks, p=products, t=V; has_product(s, p)] >= 0, Int)
+
+    m[:y_index] = y_index
+    m[:r_index] = r_index
+
+    @expression(m, total_transportation_costs,
+        sum(transport_cost_per_distance * distance(b.location, s.location) * b.capacity * r[b, p, s, t]
+            for b in sources, p in products, s in sinks, t in V if has_product(b, p);
+            init=0.0))
+
+    @expression(m, total_deviation_costs,
+        sum(b.capacity * _deviation_unit_penalty(b, p, maturation_zone(b, p, t - u)) * abs(b.target_value[p] - get_maturity_value(b, p, t - u)) * y[b, p, u, t]
+            for b in sources, p in products, u in U, t in V
+            if has_product(b, p) && t > u && _is_valid_start(b, p, u) && !isnothing(maturation_zone(b, p, t - u));
+            init=0.0))
+
+    @expression(m, total_quota_deviation_costs,
+        sum(s.overproduction_unit_penalty[p] * q_plus[s, p, t] + s.underproduction_unit_penalty[p] * q_minus[s, p, t]
+            for s in sinks, p in products, t in V if has_product(s, p);
+            init=0.0))
+
+    @objective(m, Min, total_transportation_costs + total_deviation_costs + total_quota_deviation_costs)
+
+    # (8) Deliveries to each sink meet its quota up to a penalized deviation.
+    @constraint(m, [s=sinks, p=products, t=V; has_product(s, p)],
+        sum(b.capacity * r[b, p, s, t] for b in sources if has_product(b, p); init=0.0) == s.quota[p] - q_minus[s, p, t] + q_plus[s, p, t])
+
+    # (9) Each source ships at most once across the whole horizon (all-in-all-out, across every product it can hold).
+    @constraint(m, [b=sources],
+        sum(r[b, p, s, t] for p in products, s in sinks, t in V if has_product(b, p); init=0.0) <= 1)
+
+    # (10) A source's shipment on day t equals the batch that was scheduled to exit on day t, if any.
+    @constraint(m, [b=sources, p=products, t=V; has_product(b, p)],
+        sum(r[b, p, s, t] for s in sinks; init=0.0) ==
+        sum(y[b, p, u, t] for u in U if _is_valid_start(b, p, u) && t > u && !isnothing(maturation_zone(b, p, t - u)); init=0.0))
+
+    # (11) Each source starts at most one batch across the whole horizon (across every product it can hold).
+    @constraint(m, [b=sources],
+        sum(y[b, p, u, t] for p in products, u in U, t in V
+            if has_product(b, p) && _is_valid_start(b, p, u) && t > u && !isnothing(maturation_zone(b, p, t - u));
+            init=0.0) <= 1)
+
+    # (13) A source that already holds a batch of a product must ship it during the horizon.
+    @constraint(m, [b=sources, p=products; has_product(b, p) && get(b.initial_inventory, p, 0.0) > 0],
+        sum(y[b, p, 1, t] for t in V if t > 1 && !isnothing(maturation_zone(b, p, t - 1)); init=0.0) == 1)
+
+    return m
+end
+
+"""
+    optimize_maturation_schedule!(supply_chain, optimizer=HiGHS.Optimizer; transport_cost_per_distance,
+                                  distance=haversine, is_start_day=t -> true, is_delivery_day=t -> true,
+                                  log=false, time_limit=3600.0)
+
+Builds (see [`create_maturation_scheduling_model`](@ref)) and solves the maturation-scheduling
+model for `supply_chain`, storing the result on `supply_chain.optimization_model` for
+[`get_maturation_schedule`](@ref), [`get_quota_shortfall`](@ref) and [`get_quota_excess`](@ref).
+"""
+function optimize_maturation_schedule!(supply_chain, optimizer=HiGHS.Optimizer; transport_cost_per_distance::Real,
+                                       distance=haversine, is_start_day=t -> true, is_delivery_day=t -> true,
+                                       log::Bool=false, time_limit::Real=3600.0)
+    m = create_maturation_scheduling_model(supply_chain, optimizer; transport_cost_per_distance=transport_cost_per_distance,
+                                           distance=distance, is_start_day=is_start_day, is_delivery_day=is_delivery_day)
+    set_attribute(m, "time_limit", time_limit)
+    set_attribute(m, "log_to_console", log)
+    supply_chain.optimization_model = m
+    JuMP.optimize!(m)
+    return m
+end
+
+"""
+    get_maturation_schedule(supply_chain, source::MaturationSource, product)
+
+After solving a maturation-scheduling model (see [`create_maturation_scheduling_model`](@ref)),
+gets the `(start_day, ship_day, sink)` chosen for `source`'s batch of `product`, or `nothing` if
+`source` did not ship a batch of `product` (e.g. it never held one).
+"""
+function get_maturation_schedule(supply_chain, source::MaturationSource, product)
+    m = supply_chain.optimization_model
+    y = m[:y]
+    for (b, p, u, t) in m[:y_index]
+        if b == source && p == product && value(y[b, p, u, t]) > 0.5
+            r = m[:r]
+            for (rb, rp, rs, rt) in m[:r_index]
+                if rb == source && rp == product && rt == t && value(r[rb, rp, rs, rt]) > 0.5
+                    return (start_day=u, ship_day=t, sink=rs)
+                end
+            end
+            return (start_day=u, ship_day=t, sink=nothing)
+        end
+    end
+    return nothing
+end
+
+"""
+    get_quota_shortfall(supply_chain, sink::QuotaSink, product, period)
+
+Gets the number of units by which deliveries of `product` to `sink` fell short of its quota
+during `period`, after solving (see [`create_maturation_scheduling_model`](@ref)).
+"""
+function get_quota_shortfall(supply_chain, sink::QuotaSink, product, period)
+    return value(supply_chain.optimization_model[:q_minus][sink, product, period])
+end
+
+"""
+    get_quota_excess(supply_chain, sink::QuotaSink, product, period)
+
+Gets the number of units by which deliveries of `product` to `sink` exceeded its quota during
+`period`, after solving (see [`create_maturation_scheduling_model`](@ref)).
+"""
+function get_quota_excess(supply_chain, sink::QuotaSink, product, period)
+    return value(supply_chain.optimization_model[:q_plus][sink, product, period])
+end

--- a/src/MaturationScheduling.jl
+++ b/src/MaturationScheduling.jl
@@ -107,6 +107,9 @@ function create_maturation_scheduling_model(supply_chain, optimizer=HiGHS.Optimi
     m[:y_index] = y_index
     m[:r_index] = r_index
 
+    # Named to match the paper's own four-way objective breakdown (Figure 2's OF_d, OF_w,
+    # OF_q+, OF_q-) - see get_total_deviation_costs/get_total_overproduction_costs/
+    # get_total_underproduction_costs below for the query-side counterparts.
     @expression(m, total_transportation_costs,
         sum(transport_cost_per_distance * distance(b.location, s.location) * b.capacity * r[b, p, s, t]
             for b in sources, p in products, s in sinks, t in V if has_product(b, p);
@@ -118,12 +121,21 @@ function create_maturation_scheduling_model(supply_chain, optimizer=HiGHS.Optimi
             if has_product(b, p) && t > u && _is_valid_start(b, p, u) && is_feasible_duration(b, p, t - u);
             init=0.0))
 
-    @expression(m, total_quota_deviation_costs,
-        sum(s.overproduction_unit_penalty[p] * q_plus[s, p, t] + s.underproduction_unit_penalty[p] * q_minus[s, p, t]
-            for s in sinks, p in products, t in V if has_product(s, p);
-            init=0.0))
+    @expression(m, total_overproduction_costs,
+        sum(s.overproduction_unit_penalty[p] * q_plus[s, p, t] for s in sinks, p in products, t in V if has_product(s, p); init=0.0))
 
-    @objective(m, Min, total_transportation_costs + total_deviation_costs + total_quota_deviation_costs)
+    @expression(m, total_underproduction_costs,
+        sum(s.underproduction_unit_penalty[p] * q_minus[s, p, t] for s in sinks, p in products, t in V if has_product(s, p); init=0.0))
+
+    @expression(m, total_quota_deviation_costs, total_overproduction_costs + total_underproduction_costs)
+
+    # total_costs (and reusing the transportation-cost expression's name) is deliberate: it lets
+    # the existing get_total_costs/get_total_transportation_costs from Querying.jl (written for
+    # create_network_model) work unchanged against a maturation-scheduling model's
+    # supply_chain.optimization_model too, rather than needing their own re-declared copies here.
+    @expression(m, total_costs, total_transportation_costs + total_deviation_costs + total_quota_deviation_costs)
+
+    @objective(m, Min, total_costs)
 
     # (8) Deliveries to each sink meet its quota up to a penalized deviation.
     @constraint(m, [s=sinks, p=products, t=V; has_product(s, p)],
@@ -216,4 +228,50 @@ Gets the number of units by which deliveries of `product` to `sink` exceeded its
 """
 function get_quota_excess(supply_chain, sink::QuotaSink, product, period)
     return value(supply_chain.optimization_model[:q_plus][sink, product, period])
+end
+
+"""
+    get_total_deviation_costs(supply_chain)
+
+Gets the total value-deviation penalty across every shipped batch, after solving (see
+[`create_maturation_scheduling_model`](@ref)) - the `OF_w` component of the paper's own
+objective breakdown (Figure 2). `get_total_transportation_costs` and `get_total_costs` (from
+`Querying.jl`, written for [`minimize_cost!`](@ref)/[`maximize_profits!`](@ref)'s network model)
+work unchanged against a maturation-scheduling model too.
+"""
+function get_total_deviation_costs(supply_chain)
+    return value(supply_chain.optimization_model[:total_deviation_costs])
+end
+
+"""
+    get_total_overproduction_costs(supply_chain)
+
+Gets the total overproduction (over-quota) penalty across every sink and period, after solving
+(see [`create_maturation_scheduling_model`](@ref)) - the `OF_q+` component of the paper's own
+objective breakdown (Figure 2).
+"""
+function get_total_overproduction_costs(supply_chain)
+    return value(supply_chain.optimization_model[:total_overproduction_costs])
+end
+
+"""
+    get_total_underproduction_costs(supply_chain)
+
+Gets the total underproduction (under-quota) penalty across every sink and period, after solving
+(see [`create_maturation_scheduling_model`](@ref)) - the `OF_q-` component of the paper's own
+objective breakdown (Figure 2).
+"""
+function get_total_underproduction_costs(supply_chain)
+    return value(supply_chain.optimization_model[:total_underproduction_costs])
+end
+
+"""
+    get_total_quota_deviation_costs(supply_chain)
+
+Gets the total quota-deviation penalty (over- and under-production combined) across every sink
+and period, after solving (see [`create_maturation_scheduling_model`](@ref)) - equivalent to
+`get_total_overproduction_costs(supply_chain) + get_total_underproduction_costs(supply_chain)`.
+"""
+function get_total_quota_deviation_costs(supply_chain)
+    return value(supply_chain.optimization_model[:total_quota_deviation_costs])
 end

--- a/src/MaturationScheduling.jl
+++ b/src/MaturationScheduling.jl
@@ -51,12 +51,20 @@ per unit of the source's shipped batch (`MaturationSource.capacity`).
 batches may start or ship on respectively - e.g. to exclude weekends/holidays. Both default to
 allowing every day.
 
+`integer_quota_deviation` (default `true`, matching the paper's `q_st^+, q_st^- ∈ Z_+`) makes
+the quota over/underproduction variables integer - correct when `capacity`/`quota` count
+discrete units (e.g. birds), but a trap for continuous-valued capacities (mass, currency-like
+units): an integer deviation can never exactly reconcile a fractional quota shortfall/excess,
+making the model infeasible by construction regardless of what ships. Pass `false` when
+`capacity`/`quota` aren't inherently integer.
+
 Call `JuMP.optimize!` on the returned model (or use [`optimize_maturation_schedule!`](@ref)),
 then query results with [`get_maturation_schedule`](@ref), [`get_quota_shortfall`](@ref) and
 [`get_quota_excess`](@ref).
 """
 function create_maturation_scheduling_model(supply_chain, optimizer=HiGHS.Optimizer; transport_cost_per_distance::Real,
-                                            distance=haversine, is_start_day=t -> true, is_delivery_day=t -> true)
+                                            distance=haversine, is_start_day=t -> true, is_delivery_day=t -> true,
+                                            integer_quota_deviation::Bool=true)
     check_maturation_model(supply_chain)
 
     sources = supply_chain.maturation_sources
@@ -85,9 +93,16 @@ function create_maturation_scheduling_model(supply_chain, optimizer=HiGHS.Optimi
     # r[b,p,s,t]: source b's batch of p ships to sink s on day t.
     @variable(m, r[b=sources, p=products, s=sinks, t=V; has_product(b, p)], Bin)
 
-    # q_plus/q_minus: sink s's over/under-quota deviation for p on day t.
-    @variable(m, q_plus[s=sinks, p=products, t=V; has_product(s, p)] >= 0, Int)
-    @variable(m, q_minus[s=sinks, p=products, t=V; has_product(s, p)] >= 0, Int)
+    # q_plus/q_minus: sink s's over/under-quota deviation for p on day t. Int by default
+    # (matching the paper's Z_+ domain); see integer_quota_deviation's docstring for why that's
+    # unsafe for continuous-valued capacities/quotas.
+    if integer_quota_deviation
+        @variable(m, q_plus[s=sinks, p=products, t=V; has_product(s, p)] >= 0, Int)
+        @variable(m, q_minus[s=sinks, p=products, t=V; has_product(s, p)] >= 0, Int)
+    else
+        @variable(m, q_plus[s=sinks, p=products, t=V; has_product(s, p)] >= 0)
+        @variable(m, q_minus[s=sinks, p=products, t=V; has_product(s, p)] >= 0)
+    end
 
     m[:y_index] = y_index
     m[:r_index] = r_index
@@ -139,7 +154,7 @@ end
 """
     optimize_maturation_schedule!(supply_chain, optimizer=HiGHS.Optimizer; transport_cost_per_distance,
                                   distance=haversine, is_start_day=t -> true, is_delivery_day=t -> true,
-                                  log=false, time_limit=3600.0)
+                                  integer_quota_deviation=true, log=false, time_limit=3600.0)
 
 Builds (see [`create_maturation_scheduling_model`](@ref)) and solves the maturation-scheduling
 model for `supply_chain`, storing the result on `supply_chain.optimization_model` for
@@ -147,9 +162,11 @@ model for `supply_chain`, storing the result on `supply_chain.optimization_model
 """
 function optimize_maturation_schedule!(supply_chain, optimizer=HiGHS.Optimizer; transport_cost_per_distance::Real,
                                        distance=haversine, is_start_day=t -> true, is_delivery_day=t -> true,
+                                       integer_quota_deviation::Bool=true,
                                        log::Bool=false, time_limit::Real=3600.0)
     m = create_maturation_scheduling_model(supply_chain, optimizer; transport_cost_per_distance=transport_cost_per_distance,
-                                           distance=distance, is_start_day=is_start_day, is_delivery_day=is_delivery_day)
+                                           distance=distance, is_start_day=is_start_day, is_delivery_day=is_delivery_day,
+                                           integer_quota_deviation=integer_quota_deviation)
     set_attribute(m, "time_limit", time_limit)
     set_attribute(m, "log_to_console", log)
     supply_chain.optimization_model = m

--- a/src/MaturationScheduling.jl
+++ b/src/MaturationScheduling.jl
@@ -4,7 +4,7 @@ the supply chain, mirroring `check_model`'s checks for plants/customers.
 """
 function check_maturation_model(supply_chain)
     for source in supply_chain.maturation_sources
-        for product in keys(source.initial_value)
+        for product in keys(source.value_function)
             if !(product in supply_chain.products)
                 throw(ArgumentError("MaturationSource $source has product $product that is not in the supply chain's products."))
             end
@@ -26,19 +26,6 @@ end
 # choice, so it is exempt from the turnaround gate.
 function _is_valid_start(source, product, u)
     return u > source.unavailable_periods || (u == 1 && get(source.initial_inventory, product, 0.0) > 0)
-end
-
-# The per-unit deviation penalty for a batch shipping in a given zone (see maturation_zone):
-# 0 for the ideal zone, underrun_unit_penalty/overrun_unit_penalty for the two sellable-but-
-# off-target zones.
-function _deviation_unit_penalty(source, product, zone)
-    if zone == 1
-        return source.underrun_unit_penalty[product]
-    elseif zone == 2
-        return source.overrun_unit_penalty[product]
-    else
-        return 0.0
-    end
 end
 
 """
@@ -88,12 +75,12 @@ function create_maturation_scheduling_model(supply_chain, optimizer=HiGHS.Optimi
     # iterate the exact set of valid keys as a plain Vector of tuples, rather than relying on
     # JuMP.Containers.SparseAxisArray's own iteration protocol.
     y_index = [(b, p, u, t) for b in sources, p in products, u in U, t in V
-               if has_product(b, p) && t > u && _is_valid_start(b, p, u) && !isnothing(maturation_zone(b, p, t - u))]
+               if has_product(b, p) && t > u && _is_valid_start(b, p, u) && is_feasible_duration(b, p, t - u)]
     r_index = [(b, p, s, t) for b in sources, p in products, s in sinks, t in V if has_product(b, p)]
 
     # y[b,p,u,t]: a batch of p starts at source b on day u and ships on day t.
     @variable(m, y[b=sources, p=products, u=U, t=V;
-                   has_product(b, p) && t > u && _is_valid_start(b, p, u) && !isnothing(maturation_zone(b, p, t - u))], Bin)
+                   has_product(b, p) && t > u && _is_valid_start(b, p, u) && is_feasible_duration(b, p, t - u)], Bin)
 
     # r[b,p,s,t]: source b's batch of p ships to sink s on day t.
     @variable(m, r[b=sources, p=products, s=sinks, t=V; has_product(b, p)], Bin)
@@ -111,9 +98,9 @@ function create_maturation_scheduling_model(supply_chain, optimizer=HiGHS.Optimi
             init=0.0))
 
     @expression(m, total_deviation_costs,
-        sum(b.capacity * _deviation_unit_penalty(b, p, maturation_zone(b, p, t - u)) * abs(b.target_value[p] - get_maturity_value(b, p, t - u)) * y[b, p, u, t]
+        sum(b.capacity * get_duration_penalty(b, p, t - u) * y[b, p, u, t]
             for b in sources, p in products, u in U, t in V
-            if has_product(b, p) && t > u && _is_valid_start(b, p, u) && !isnothing(maturation_zone(b, p, t - u));
+            if has_product(b, p) && t > u && _is_valid_start(b, p, u) && is_feasible_duration(b, p, t - u);
             init=0.0))
 
     @expression(m, total_quota_deviation_costs,
@@ -134,17 +121,17 @@ function create_maturation_scheduling_model(supply_chain, optimizer=HiGHS.Optimi
     # (10) A source's shipment on day t equals the batch that was scheduled to exit on day t, if any.
     @constraint(m, [b=sources, p=products, t=V; has_product(b, p)],
         sum(r[b, p, s, t] for s in sinks; init=0.0) ==
-        sum(y[b, p, u, t] for u in U if _is_valid_start(b, p, u) && t > u && !isnothing(maturation_zone(b, p, t - u)); init=0.0))
+        sum(y[b, p, u, t] for u in U if _is_valid_start(b, p, u) && t > u && is_feasible_duration(b, p, t - u); init=0.0))
 
     # (11) Each source starts at most one batch across the whole horizon (across every product it can hold).
     @constraint(m, [b=sources],
         sum(y[b, p, u, t] for p in products, u in U, t in V
-            if has_product(b, p) && _is_valid_start(b, p, u) && t > u && !isnothing(maturation_zone(b, p, t - u));
+            if has_product(b, p) && _is_valid_start(b, p, u) && t > u && is_feasible_duration(b, p, t - u);
             init=0.0) <= 1)
 
     # (13) A source that already holds a batch of a product must ship it during the horizon.
     @constraint(m, [b=sources, p=products; has_product(b, p) && get(b.initial_inventory, p, 0.0) > 0],
-        sum(y[b, p, 1, t] for t in V if t > 1 && !isnothing(maturation_zone(b, p, t - 1)); init=0.0) == 1)
+        sum(y[b, p, 1, t] for t in V if t > 1 && is_feasible_duration(b, p, t - 1); init=0.0) == 1)
 
     return m
 end

--- a/src/Modeling.jl
+++ b/src/Modeling.jl
@@ -52,53 +52,41 @@ function get_sent_time(lane, destination, receipt_time)
     return sent_time
 end
 
-# maturation_zone/feasible_exits below implement Figure 1 and equations (1)-(6) of Gbéya,
-# Darvish, Renaud and Coelho (2026), "Integrated Poultry Production-Distribution
-# Optimization", CIRRELT-2026-10, generalized from a single global target/deviation to
-# per-(MaturationSource, Product) values (see MaturationSource.add_product!).
+# is_feasible_duration/get_duration_penalty/feasible_exits below drive the maturation-scheduling
+# model purely off a MaturationSource's registered age-value curve (see
+# MaturationSource.add_product!) - no assumption of linearity or any particular curve shape, so
+# they work identically whether that curve was built via the linear/%-band convenience form or
+# a fully custom one (e.g. a classical shelf-life curve).
 
-# Returns the four value thresholds delimiting the three sellable zones (and the
-# unsellable region beyond them) around a MaturationSource's target_value for a product.
-function _maturation_zone_bounds(source, product)
-    W = source.target_value[product]
-    lower_extended = (1 - source.acceptable_deviation_under[product] - source.extended_deviation_under[product]) * W
-    lower_acceptable = (1 - source.acceptable_deviation_under[product]) * W
-    upper_acceptable = (1 + source.acceptable_deviation_over[product]) * W
-    upper_extended = (1 + source.acceptable_deviation_over[product] + source.extended_deviation_over[product]) * W
-    return (lower_extended, lower_acceptable, upper_acceptable, upper_extended)
+"""
+    is_feasible_duration(source, product, duration)
+
+Checks whether a batch of `product` at `source` may ship after being held `duration` periods,
+per the source's registered feasibility curve (see `MaturationSource.add_product!`).
+"""
+function is_feasible_duration(source, product, duration)
+    return source.feasible_duration[product](duration)
 end
 
 """
-    maturation_zone(source, product, duration)
+    get_duration_penalty(source, product, duration)
 
-Classifies a batch's value after being held `duration` periods into one of three zones: `0`
-(ideal/on-target), `1` (below target but still sellable, e.g. to an alternative market), `2`
-(above target but still sellable). Returns `nothing` if the value falls outside even the
-extended-sellable range, meaning a batch cannot ship at that duration.
+Gets the per-unit cost of shipping a batch of `product` at `source` after being held `duration`
+periods, per the source's registered penalty curve (zero within its ideal range).
 """
-function maturation_zone(source, product, duration)
-    value = get_maturity_value(source, product, duration)
-    lower_extended, lower_acceptable, upper_acceptable, upper_extended = _maturation_zone_bounds(source, product)
-    if lower_acceptable <= value <= upper_acceptable
-        return 0
-    elseif lower_extended <= value < lower_acceptable
-        return 1
-    elseif upper_acceptable < value <= upper_extended
-        return 2
-    else
-        return nothing
-    end
+function get_duration_penalty(source, product, duration)
+    return source.duration_penalty[product](duration)
 end
 
 """
     feasible_exits(source, product, U, V)
 
-For a `MaturationSource`/product, computes every feasible `(start_day, ship_day, zone)` triple
-given candidate start days `U` and candidate ship days `V`: `zone` is `0`, `1`, or `2` (see
-`maturation_zone`). Start days at or before `source.unavailable_periods` are excluded (the
-source cannot begin a new batch during its mandatory turnaround). If the source already holds
-a batch of `product` (`initial_inventory[product] > 0`), day `1` is always included as a start
-day regardless of `U` or `unavailable_periods`: `initial_value` already reflects that batch's
+For a `MaturationSource`/product, computes every feasible `(start_day, ship_day)` pair given
+candidate start days `U` and candidate ship days `V` (see [`is_feasible_duration`](@ref)). Start
+days at or before `source.unavailable_periods` are excluded (the source cannot begin a new batch
+during its mandatory turnaround). If the source already holds a batch of `product`
+(`initial_inventory[product] > 0`), day `1` is always included as a start day regardless of `U`
+or `unavailable_periods`: the batch's registered value at duration `0` already reflects its
 *current* value as of day 1 of the horizon, so day 1 is a bookkeeping reference for an
 in-progress batch rather than a new scheduling choice.
 """
@@ -106,12 +94,10 @@ function feasible_exits(source, product, U, V)
     fresh_starts = [u for u in U if u > source.unavailable_periods]
     u_candidates = get(source.initial_inventory, product, 0.0) > 0 ? union(fresh_starts, (1,)) : fresh_starts
 
-    triples = Tuple{Int, Int, Int}[]
+    pairs = Tuple{Int, Int}[]
     for u in u_candidates, t in V
         t <= u && continue
-        zone = maturation_zone(source, product, t - u)
-        isnothing(zone) && continue
-        push!(triples, (u, t, zone))
+        is_feasible_duration(source, product, t - u) && push!(pairs, (u, t))
     end
-    return triples
+    return pairs
 end

--- a/src/Modeling.jl
+++ b/src/Modeling.jl
@@ -51,3 +51,67 @@ function get_sent_time(lane, destination, receipt_time)
     sent_time = receipt_time - transit_time
     return sent_time
 end
+
+# maturation_zone/feasible_exits below implement Figure 1 and equations (1)-(6) of Gbéya,
+# Darvish, Renaud and Coelho (2026), "Integrated Poultry Production-Distribution
+# Optimization", CIRRELT-2026-10, generalized from a single global target/deviation to
+# per-(MaturationSource, Product) values (see MaturationSource.add_product!).
+
+# Returns the four value thresholds delimiting the three sellable zones (and the
+# unsellable region beyond them) around a MaturationSource's target_value for a product.
+function _maturation_zone_bounds(source, product)
+    W = source.target_value[product]
+    lower_extended = (1 - source.acceptable_deviation_under[product] - source.extended_deviation_under[product]) * W
+    lower_acceptable = (1 - source.acceptable_deviation_under[product]) * W
+    upper_acceptable = (1 + source.acceptable_deviation_over[product]) * W
+    upper_extended = (1 + source.acceptable_deviation_over[product] + source.extended_deviation_over[product]) * W
+    return (lower_extended, lower_acceptable, upper_acceptable, upper_extended)
+end
+
+"""
+    maturation_zone(source, product, duration)
+
+Classifies a batch's value after being held `duration` periods into one of three zones: `0`
+(ideal/on-target), `1` (below target but still sellable, e.g. to an alternative market), `2`
+(above target but still sellable). Returns `nothing` if the value falls outside even the
+extended-sellable range, meaning a batch cannot ship at that duration.
+"""
+function maturation_zone(source, product, duration)
+    value = get_maturity_value(source, product, duration)
+    lower_extended, lower_acceptable, upper_acceptable, upper_extended = _maturation_zone_bounds(source, product)
+    if lower_acceptable <= value <= upper_acceptable
+        return 0
+    elseif lower_extended <= value < lower_acceptable
+        return 1
+    elseif upper_acceptable < value <= upper_extended
+        return 2
+    else
+        return nothing
+    end
+end
+
+"""
+    feasible_exits(source, product, U, V)
+
+For a `MaturationSource`/product, computes every feasible `(start_day, ship_day, zone)` triple
+given candidate start days `U` and candidate ship days `V`: `zone` is `0`, `1`, or `2` (see
+`maturation_zone`). Start days at or before `source.unavailable_periods` are excluded (the
+source cannot begin a new batch during its mandatory turnaround). If the source already holds
+a batch of `product` (`initial_inventory[product] > 0`), day `1` is always included as a start
+day regardless of `U` or `unavailable_periods`: `initial_value` already reflects that batch's
+*current* value as of day 1 of the horizon, so day 1 is a bookkeeping reference for an
+in-progress batch rather than a new scheduling choice.
+"""
+function feasible_exits(source, product, U, V)
+    fresh_starts = [u for u in U if u > source.unavailable_periods]
+    u_candidates = get(source.initial_inventory, product, 0.0) > 0 ? union(fresh_starts, (1,)) : fresh_starts
+
+    triples = Tuple{Int, Int, Int}[]
+    for u in u_candidates, t in V
+        t <= u && continue
+        zone = maturation_zone(source, product, t - u)
+        isnothing(zone) && continue
+        push!(triples, (u, t, zone))
+    end
+    return triples
+end

--- a/src/SupplyChainOptimization.jl
+++ b/src/SupplyChainOptimization.jl
@@ -8,6 +8,7 @@ include("Visualization.jl")
 include("Optimization.jl")
 include("GSM.jl")
 include("MaturationScheduling.jl")
+include("Matheuristics.jl")
 
 using Base: Bool, product
 using JuMP
@@ -50,7 +51,8 @@ export minimize_cost!,
       optimize_maturation_schedule!,
       get_maturation_schedule,
       get_quota_shortfall,
-      get_quota_excess
+      get_quota_excess,
+      matheuristic_optimize!
 
 function check_model(supply_chain)
     for production in supply_chain.plants

--- a/src/SupplyChainOptimization.jl
+++ b/src/SupplyChainOptimization.jl
@@ -52,6 +52,10 @@ export minimize_cost!,
       get_maturation_schedule,
       get_quota_shortfall,
       get_quota_excess,
+      get_total_deviation_costs,
+      get_total_overproduction_costs,
+      get_total_underproduction_costs,
+      get_total_quota_deviation_costs,
       matheuristic_optimize!
 
 function check_model(supply_chain)

--- a/src/SupplyChainOptimization.jl
+++ b/src/SupplyChainOptimization.jl
@@ -7,6 +7,7 @@ include("Querying.jl")
 include("Visualization.jl")
 include("Optimization.jl")
 include("GSM.jl")
+include("MaturationScheduling.jl")
 
 using Base: Bool, product
 using JuMP
@@ -29,6 +30,7 @@ export minimize_cost!,
       is_opening,
       is_closing,
       haversine,
+      haversine_km,
       plot_flows,
       plot_costs,
       animate_flows,
@@ -43,7 +45,12 @@ export minimize_cost!,
       get_outgoing_service_time,
       get_net_replenishment_time,
       get_safety_stock,
-      get_total_safety_stock_cost
+      get_total_safety_stock_cost,
+      create_maturation_scheduling_model,
+      optimize_maturation_schedule!,
+      get_maturation_schedule,
+      get_quota_shortfall,
+      get_quota_excess
 
 function check_model(supply_chain)
     for production in supply_chain.plants
@@ -146,6 +153,17 @@ function haversine(lat1, lon1, lat2, lon2)
     Δlon = lon2 - lon1
 
     return 2 * R * asin(sqrt(sind(Δlat / 2) ^ 2 + cosd(lat1) * cosd(lat2) * sind(Δlon / 2) ^ 2))
+end
+
+"""
+    haversine_km(location1::Location, location2::Location)
+
+Computes the great circle distance between two locations, in kilometers - a convenience over
+[`haversine`](@ref) (which returns meters) for callers pricing distance per kilometer, e.g.
+[`create_maturation_scheduling_model`](@ref)'s `transport_cost_per_distance`.
+"""
+function haversine_km(location1::Location, location2::Location)
+    return haversine(location1, location2) / 1000.0
 end
 
 end # module

--- a/test/MatheuristicBenchmark.jl
+++ b/test/MatheuristicBenchmark.jl
@@ -16,10 +16,16 @@ function _random_maturation_benchmark_instance(num_farms::Int, horizon::Int)
     # window) fixes the growth rate needed to land exactly on target_value at that duration -
     # guarantees every farm has a real, reachable ideal window within the horizon, rather than
     # risking an unsatisfiable random instance that would make the comparison meaningless.
+    # Capacities are integer-valued (birds are countable units, matching the paper's own
+    # instance generator) so the quota below - and every multiple of it constraint (8) sums -
+    # comes out integer too. create_maturation_scheduling_model's q_plus/q_minus are integer by
+    # default (see its integer_quota_deviation docstring): a fractional quota target could never
+    # be reconciled exactly by an integer deviation, making the model infeasible by construction
+    # regardless of what ships - the trap this instance is built to avoid, not work around.
     for f in 1:num_farms
         target_duration = 24.0 + rand() * 8.0
         growth_rate = (target_value - initial_value) / target_duration
-        capacity = 4000.0 + rand() * (32000.0 - 4000.0)
+        capacity = Float64(rand(4000:32000))
         farm = MaturationSource("farm$f", Location(45.0 + rand(), -73.0 + rand()); capacity=capacity)
         add_product!(farm, product; initial_value=initial_value, maturation_rate=growth_rate, target_value=target_value,
                                     acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
@@ -30,7 +36,7 @@ function _random_maturation_benchmark_instance(num_farms::Int, horizon::Int)
 
     total_capacity = sum(f.capacity for f in sc.maturation_sources)
     sink = QuotaSink("slaughterhouse1", Location(45.5, -73.5))
-    add_product!(sink, product; quota=total_capacity / horizon, underproduction_unit_penalty=1.0, overproduction_unit_penalty=1.0)
+    add_product!(sink, product; quota=round(total_capacity / horizon), underproduction_unit_penalty=1.0, overproduction_unit_penalty=1.0)
     add_quota_sink!(sc, sink)
 
     return sc

--- a/test/MatheuristicBenchmark.jl
+++ b/test/MatheuristicBenchmark.jl
@@ -1,0 +1,79 @@
+using Dates
+
+# A synthetic instance at roughly the scale the CIRRELT-2026-10 paper itself found hard for a
+# direct commercial solver (tens of farms, a multi-week horizon) - small UFLlib instances
+# elsewhere in this test suite solve to proven optimality in a fraction of a second, which
+# proves matheuristic_optimize! doesn't regress but says nothing about whether it actually
+# helps. This is deliberately sized to be non-trivial under a short, CI-friendly time budget.
+function _random_maturation_benchmark_instance(num_farms::Int, horizon::Int)
+    sc = SupplyChain(horizon)
+    product = Product("bird")
+    add_product!(sc, product)
+
+    target_value = 22500.0
+    initial_value = 45.0
+    # A duration uniformly drawn from [24, 32] days (within the paper's 3-5 week breeding
+    # window) fixes the growth rate needed to land exactly on target_value at that duration -
+    # guarantees every farm has a real, reachable ideal window within the horizon, rather than
+    # risking an unsatisfiable random instance that would make the comparison meaningless.
+    for f in 1:num_farms
+        target_duration = 24.0 + rand() * 8.0
+        growth_rate = (target_value - initial_value) / target_duration
+        capacity = 4000.0 + rand() * (32000.0 - 4000.0)
+        farm = MaturationSource("farm$f", Location(45.0 + rand(), -73.0 + rand()); capacity=capacity)
+        add_product!(farm, product; initial_value=initial_value, maturation_rate=growth_rate, target_value=target_value,
+                                    acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
+                                    extended_deviation_under=0.05, extended_deviation_over=0.05,
+                                    underrun_unit_penalty=0.0007, overrun_unit_penalty=0.001)
+        add_maturation_source!(sc, farm)
+    end
+
+    total_capacity = sum(f.capacity for f in sc.maturation_sources)
+    sink = QuotaSink("slaughterhouse1", Location(45.5, -73.5))
+    add_product!(sink, product; quota=total_capacity / horizon, underproduction_unit_penalty=1.0, overproduction_unit_penalty=1.0)
+    add_quota_sink!(sc, sink)
+
+    return sc
+end
+
+@testset "MatheuristicBenchmark" begin
+
+@test begin
+    sc = _random_maturation_benchmark_instance(60, 42)
+
+    direct_time_limit = 20.0
+    m_direct = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0, distance=haversine_km)
+    set_attribute(m_direct, "time_limit", direct_time_limit)
+    set_silent(m_direct)
+    direct_start = Dates.now()
+    JuMP.optimize!(m_direct)
+    direct_elapsed = Dates.now() - direct_start
+    direct_objective = has_values(m_direct) ? objective_value(m_direct) : Inf
+    direct_gap = try
+        relative_gap(m_direct)
+    catch
+        NaN
+    end
+
+    m_heuristic = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0, distance=haversine_km)
+    set_silent(m_heuristic)
+    heuristic_start = Dates.now()
+    SupplyChainOptimization.matheuristic_optimize!(m_heuristic; iterations=4, fix_fraction=0.85, time_limit_per_iteration=6.0)
+    heuristic_elapsed = Dates.now() - heuristic_start
+    heuristic_objective = has_values(m_heuristic) ? objective_value(m_heuristic) : Inf
+
+    println("--- Matheuristic benchmark (60 farms, 42-day horizon) ---")
+    println("Direct solve:      objective=$direct_objective, gap=$direct_gap, time=$direct_elapsed (time_limit=$(direct_time_limit)s)")
+    println("Matheuristic:       objective=$heuristic_objective, time=$heuristic_elapsed (4 iterations x 6s + initial solve)")
+    if isfinite(direct_objective) && isfinite(heuristic_objective)
+        pct = 100 * (direct_objective - heuristic_objective) / direct_objective
+        println("Matheuristic vs direct: $(round(pct; digits=2))% $(pct >= 0 ? "better" : "worse")")
+    end
+
+    # A correctness floor, not a performance gate (shared CI hardware timing is too noisy for a
+    # strict performance assertion to be anything but flaky) - both approaches must at least
+    # find *a* feasible solution on an instance built to be satisfiable by construction.
+    isfinite(direct_objective) && isfinite(heuristic_objective)
+end
+
+end

--- a/test/MatheuristicBenchmark.jl
+++ b/test/MatheuristicBenchmark.jl
@@ -1,11 +1,14 @@
 using Dates
 
 # A synthetic instance at roughly the scale the CIRRELT-2026-10 paper itself found hard for a
-# direct commercial solver (tens of farms, a multi-week horizon) - small UFLlib instances
-# elsewhere in this test suite solve to proven optimality in a fraction of a second, which
-# proves matheuristic_optimize! doesn't regress but says nothing about whether it actually
-# helps. This is deliberately sized to be non-trivial under a short, CI-friendly time budget.
-function _random_maturation_benchmark_instance(num_farms::Int, horizon::Int)
+# direct commercial solver - small UFLlib instances elsewhere in this test suite solve to proven
+# optimality in a fraction of a second, which proves matheuristic_optimize! doesn't regress but
+# says nothing about whether it actually helps. A first attempt at 60 farms/1 sink also turned
+# out too easy (HiGHS proved optimality in well under a second - see the commit history for
+# that result): the paper's own difficulty comes less from farm count alone than from splitting
+# the assignment across multiple slaughterhouses, so num_sinks matters at least as much as
+# num_farms here.
+function _random_maturation_benchmark_instance(num_farms::Int, num_sinks::Int, horizon::Int)
     sc = SupplyChain(horizon)
     product = Product("bird")
     add_product!(sc, product)
@@ -17,8 +20,8 @@ function _random_maturation_benchmark_instance(num_farms::Int, horizon::Int)
     # guarantees every farm has a real, reachable ideal window within the horizon, rather than
     # risking an unsatisfiable random instance that would make the comparison meaningless.
     # Capacities are integer-valued (birds are countable units, matching the paper's own
-    # instance generator) so the quota below - and every multiple of it constraint (8) sums -
-    # comes out integer too. create_maturation_scheduling_model's q_plus/q_minus are integer by
+    # instance generator) so quotas below - and every multiple of them constraint (8) sums -
+    # come out integer too. create_maturation_scheduling_model's q_plus/q_minus are integer by
     # default (see its integer_quota_deviation docstring): a fractional quota target could never
     # be reconciled exactly by an integer deviation, making the model infeasible by construction
     # regardless of what ships - the trap this instance is built to avoid, not work around.
@@ -34,10 +37,17 @@ function _random_maturation_benchmark_instance(num_farms::Int, horizon::Int)
         add_maturation_source!(sc, farm)
     end
 
+    # Roughly mirrors the paper's own 50/30/20-style split across slaughterhouses, generalized
+    # to any num_sinks: shares decrease geometrically and are renormalized to sum to 1.
+    raw_shares = [0.6^(i - 1) for i in 1:num_sinks]
+    shares = raw_shares ./ sum(raw_shares)
     total_capacity = sum(f.capacity for f in sc.maturation_sources)
-    sink = QuotaSink("slaughterhouse1", Location(45.5, -73.5))
-    add_product!(sink, product; quota=round(total_capacity / horizon), underproduction_unit_penalty=1.0, overproduction_unit_penalty=1.0)
-    add_quota_sink!(sc, sink)
+    for (i, share) in enumerate(shares)
+        sink = QuotaSink("slaughterhouse$i", Location(45.5 + rand(), -73.5 + rand()))
+        add_product!(sink, product; quota=round(share * total_capacity / horizon),
+                                    underproduction_unit_penalty=1.0, overproduction_unit_penalty=1.0)
+        add_quota_sink!(sc, sink)
+    end
 
     return sc
 end
@@ -45,9 +55,10 @@ end
 @testset "MatheuristicBenchmark" begin
 
 @test begin
-    sc = _random_maturation_benchmark_instance(60, 42)
+    num_farms, num_sinks, horizon = 200, 3, 63
+    sc = _random_maturation_benchmark_instance(num_farms, num_sinks, horizon)
 
-    direct_time_limit = 20.0
+    direct_time_limit = 30.0
     m_direct = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0, distance=haversine_km)
     set_attribute(m_direct, "time_limit", direct_time_limit)
     set_silent(m_direct)
@@ -64,13 +75,13 @@ end
     m_heuristic = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0, distance=haversine_km)
     set_silent(m_heuristic)
     heuristic_start = Dates.now()
-    SupplyChainOptimization.matheuristic_optimize!(m_heuristic; iterations=4, fix_fraction=0.85, time_limit_per_iteration=6.0)
+    SupplyChainOptimization.matheuristic_optimize!(m_heuristic; iterations=5, fix_fraction=0.85, time_limit_per_iteration=6.0)
     heuristic_elapsed = Dates.now() - heuristic_start
     heuristic_objective = has_values(m_heuristic) ? objective_value(m_heuristic) : Inf
 
-    println("--- Matheuristic benchmark (60 farms, 42-day horizon) ---")
+    println("--- Matheuristic benchmark ($num_farms farms, $num_sinks sinks, $horizon-day horizon) ---")
     println("Direct solve:      objective=$direct_objective, gap=$direct_gap, time=$direct_elapsed (time_limit=$(direct_time_limit)s)")
-    println("Matheuristic:       objective=$heuristic_objective, time=$heuristic_elapsed (4 iterations x 6s + initial solve)")
+    println("Matheuristic:       objective=$heuristic_objective, time=$heuristic_elapsed (5 iterations x 6s + initial solve)")
     if isfinite(direct_objective) && isfinite(heuristic_objective)
         pct = 100 * (direct_objective - heuristic_objective) / direct_objective
         println("Matheuristic vs direct: $(round(pct; digits=2))% $(pct >= 0 ? "better" : "worse")")

--- a/test/Matheuristics.jl
+++ b/test/Matheuristics.jl
@@ -1,0 +1,121 @@
+using HiGHS
+
+@testset "Matheuristics" begin
+
+# A tiny 0/1 knapsack with a hand-verified optimum: values [10,6,4,3,1], weights [6,5,4,3,1],
+# capacity 10. Best subset by exhaustive check is {item 1, item 3} (weight 6+4=10, value
+# 10+4=14) - HiGHS solves this to proven optimality on its own single solve already, so this
+# mainly checks that matheuristic_optimize! does not *regress* an already-optimal solution, and
+# that it correctly restores bounds afterward (item 5's variable is deliberately given only a
+# lower bound, matching how q_plus/q_minus are declared in MaturationScheduling.jl, to exercise
+# the "originally unbounded above" restore path).
+function build_knapsack()
+    values = [10.0, 6.0, 4.0, 3.0, 1.0]
+    weights = [6.0, 5.0, 4.0, 3.0, 1.0]
+    m = Model(HiGHS.Optimizer)
+    set_silent(m)
+    @variable(m, x[1:4], Bin)
+    @variable(m, x5 >= 0, Int)
+    set_upper_bound(x5, 1)
+    @constraint(m, sum(weights[i] * x[i] for i in 1:4) + weights[5] * x5 <= 10)
+    @objective(m, Max, sum(values[i] * x[i] for i in 1:4) + values[5] * x5)
+    return m, x5
+end
+
+@test begin
+    m, x5 = build_knapsack()
+    JuMP.optimize!(m)
+
+    has_upper_before = has_upper_bound(x5)  # true: manually set above, unlike q_plus/q_minus's own declarations
+
+    SupplyChainOptimization.matheuristic_optimize!(m; iterations=5, fix_fraction=0.5)
+
+    objective_value(m) ≈ 14.0 && has_upper_bound(x5) == has_upper_before
+end
+
+@test begin
+    m, x5 = build_knapsack()
+    JuMP.optimize!(m)
+    SupplyChainOptimization.matheuristic_optimize!(m; iterations=5, neighborhood=:local_branching, local_branching_k=2)
+    objective_value(m) ≈ 14.0
+end
+
+# The lower-bound-only variable (matching q_plus/q_minus's own `>= 0, Int` declaration, no
+# explicit upper bound) must come back with no upper bound after matheuristic_optimize! - not
+# stuck at whatever value pinning last set it to.
+@test begin
+    m = Model(HiGHS.Optimizer)
+    set_silent(m)
+    @variable(m, y >= 0, Int)
+    @constraint(m, y <= 7.4)
+    @objective(m, Max, y)
+    JuMP.optimize!(m)
+
+    SupplyChainOptimization.matheuristic_optimize!(m; iterations=3)
+
+    value(y) ≈ 7.0 && !has_upper_bound(y) && has_lower_bound(y) && lower_bound(y) == 0.0
+end
+
+@test_throws ArgumentError begin
+    m, _ = build_knapsack()
+    JuMP.optimize!(m)
+    SupplyChainOptimization.matheuristic_optimize!(m; neighborhood=:bogus)
+end
+
+@test_throws ArgumentError begin
+    m, _ = build_knapsack()
+    JuMP.optimize!(m)
+    SupplyChainOptimization.matheuristic_optimize!(m; fix_fraction=1.5)
+end
+
+# A pure LP (no integer/binary variables at all) has no neighborhood to explore - the model
+# should come back unchanged rather than erroring.
+@test begin
+    m = Model(HiGHS.Optimizer)
+    set_silent(m)
+    @variable(m, 0 <= z <= 5)
+    @objective(m, Max, z)
+    JuMP.optimize!(m)
+
+    SupplyChainOptimization.matheuristic_optimize!(m; iterations=3)
+    objective_value(m) ≈ 5.0
+end
+
+# Smoke tests against this package's own model types - matheuristic_optimize! must not make
+# either model type's solution worse than the direct solve found on its own.
+@test begin
+    sc = create_model_storage_customer()
+    SupplyChainOptimization.minimize_cost!(sc)
+    direct_cost = get_total_costs(sc)
+
+    SupplyChainOptimization.matheuristic_optimize!(sc.optimization_model; iterations=3)
+
+    objective_value(sc.optimization_model) <= direct_cost + 1e-6
+end
+
+@test begin
+    sc = SupplyChain(20)
+    product = Product("batch")
+    add_product!(sc, product)
+
+    source = MaturationSource("s1", Location(0.0, 0.0); capacity=100)
+    add_product!(source, product; initial_value=0.0, maturation_rate=10.0, target_value=100.0,
+                                  acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
+                                  extended_deviation_under=0.1, extended_deviation_over=0.1)
+    add_maturation_source!(sc, source)
+
+    sink = QuotaSink("k1", Location(0.0, 0.0))
+    add_product!(sink, product; quota=100.0, underproduction_unit_penalty=5.0, overproduction_unit_penalty=5.0)
+    add_quota_sink!(sc, sink)
+
+    m = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0,
+                                           distance=(a, b) -> 1.0, is_delivery_day=t -> t == 10)
+    JuMP.optimize!(m)
+    direct_objective = objective_value(m)
+
+    SupplyChainOptimization.matheuristic_optimize!(m; iterations=3)
+
+    objective_value(m) <= direct_objective + 1e-6
+end
+
+end

--- a/test/Matheuristics.jl
+++ b/test/Matheuristics.jl
@@ -33,6 +33,20 @@ end
     objective_value(m) ≈ 14.0 && has_upper_bound(x5) == has_upper_before
 end
 
+# matheuristic_optimize! leaves the model warm-started (JuMP.set_start_value persists across
+# optimize! calls, not cleared automatically) - a caller should be able to hand the model to a
+# subsequent, independent solve (e.g. a longer or exact one) and have it pick up where the
+# search left off, not error or silently discard the incumbent.
+@test begin
+    m, _ = build_knapsack()
+    JuMP.optimize!(m)
+    SupplyChainOptimization.matheuristic_optimize!(m; iterations=3)
+    first_objective = objective_value(m)
+
+    JuMP.optimize!(m)
+    objective_value(m) ≈ first_objective ≈ 14.0
+end
+
 @test begin
     m, x5 = build_knapsack()
     JuMP.optimize!(m)

--- a/test/MaturationScheduling.jl
+++ b/test/MaturationScheduling.jl
@@ -213,16 +213,19 @@ end
         2 <= schedule.ship_day - schedule.start_day <= 5
 end
 
-# integer_quota_deviation=true (the default) requires quota/capacity to be integer-valued: an
-# integer q_plus/q_minus can never exactly reconcile a fractional target, so a fractional
-# capacity/quota makes the model infeasible regardless of what ships. integer_quota_deviation=
-# false lifts that restriction.
+# integer_quota_deviation=true (the default) requires quota/capacity to be integer-valued - but
+# not merely "fractional" in isolation: with a single source, the only two possible shipped
+# quantities are 0 (don't ship) or capacity (ship). If quota happens to share capacity's
+# fractional part (e.g. both 100.5), shipping alone reconciles the equation exactly with q=0,
+# no integrality conflict at all. The real trap is a *mismatch*: capacity integer (100) but
+# quota fractional (100.5) means neither branch's gap (100.5 or 0.5) is an integer, so no
+# integer q_plus/q_minus can bridge either one - genuinely infeasible, not just fractional.
 @test begin
     sc = SupplyChain(20)
     product = Product("batch")
     add_product!(sc, product)
 
-    source = MaturationSource("s1", Location(0.0, 0.0); capacity=100.5)
+    source = MaturationSource("s1", Location(0.0, 0.0); capacity=100.0)
     add_product!(source, product; initial_value=0.0, maturation_rate=10.0, target_value=100.0,
                                   acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
                                   extended_deviation_under=0.1, extended_deviation_over=0.1)

--- a/test/MaturationScheduling.jl
+++ b/test/MaturationScheduling.jl
@@ -213,4 +213,35 @@ end
         2 <= schedule.ship_day - schedule.start_day <= 5
 end
 
+# integer_quota_deviation=true (the default) requires quota/capacity to be integer-valued: an
+# integer q_plus/q_minus can never exactly reconcile a fractional target, so a fractional
+# capacity/quota makes the model infeasible regardless of what ships. integer_quota_deviation=
+# false lifts that restriction.
+@test begin
+    sc = SupplyChain(20)
+    product = Product("batch")
+    add_product!(sc, product)
+
+    source = MaturationSource("s1", Location(0.0, 0.0); capacity=100.5)
+    add_product!(source, product; initial_value=0.0, maturation_rate=10.0, target_value=100.0,
+                                  acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
+                                  extended_deviation_under=0.1, extended_deviation_over=0.1)
+    add_maturation_source!(sc, source)
+
+    sink = QuotaSink("k1", Location(0.0, 0.0))
+    add_product!(sink, product; quota=100.5, underproduction_unit_penalty=1.0, overproduction_unit_penalty=1.0)
+    add_quota_sink!(sc, sink)
+
+    m_integer = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0,
+                                                    distance=(a, b) -> 1.0, is_delivery_day=t -> t == 10)
+    JuMP.optimize!(m_integer)
+
+    m_continuous = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0,
+                                                       distance=(a, b) -> 1.0, is_delivery_day=t -> t == 10,
+                                                       integer_quota_deviation=false)
+    JuMP.optimize!(m_continuous)
+
+    termination_status(m_integer) == INFEASIBLE && termination_status(m_continuous) == OPTIMAL
+end
+
 end

--- a/test/MaturationScheduling.jl
+++ b/test/MaturationScheduling.jl
@@ -1,0 +1,176 @@
+@testset "MaturationScheduling" begin
+
+# --- pure helper functions (no solve needed) ---
+
+@test begin
+    # target 100, +/-10% acceptable, +/-10% further extended -> acceptable [90,110],
+    # sellable-but-off-target [80,90) and (110,120], unsellable outside [80,120].
+    product = Product("batch")
+    source = MaturationSource("s1", Location(0.0, 0.0); capacity=100)
+    add_product!(source, product; initial_value=0.0, maturation_rate=10.0, target_value=100.0,
+                                  acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
+                                  extended_deviation_under=0.1, extended_deviation_over=0.1)
+
+    SupplyChainOptimization.maturation_zone(source, product, 7) === nothing &&   # value=70, below even the extended range
+    SupplyChainOptimization.maturation_zone(source, product, 8) == 1 &&   # value=80, sellable underrun
+    SupplyChainOptimization.maturation_zone(source, product, 9) == 0 &&   # value=90, ideal (boundary)
+    SupplyChainOptimization.maturation_zone(source, product, 10) == 0 &&  # value=100, ideal
+    SupplyChainOptimization.maturation_zone(source, product, 11) == 0 &&  # value=110, ideal (boundary)
+    SupplyChainOptimization.maturation_zone(source, product, 12) == 2 &&  # value=120, sellable overrun
+    SupplyChainOptimization.maturation_zone(source, product, 13) === nothing  # value=130, unsellable
+end
+
+@test begin
+    # feasible_exits should exclude start days at/before unavailable_periods, and only pair a
+    # start day u with ship days t giving a sellable (non-nothing) zone.
+    product = Product("batch")
+    source = MaturationSource("s1", Location(0.0, 0.0); capacity=100, unavailable_periods=3)
+    add_product!(source, product; initial_value=0.0, maturation_rate=10.0, target_value=100.0,
+                                  acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
+                                  extended_deviation_under=0.1, extended_deviation_over=0.1)
+
+    triples = SupplyChainOptimization.feasible_exits(source, product, 1:5, 1:20)
+    # No triple should ever start at u<=3 (the unavailable/sanitation period).
+    all(u > 3 for (u, t, zone) in triples) &&
+        (4, 13, 0) in triples &&   # u=4, duration=9 -> value=90 -> zone 0 (ideal, boundary)
+        (4, 12, 1) in triples      # u=4, duration=8 -> value=80 -> zone 1 (sellable underrun)
+end
+
+@test begin
+    # A source that already holds a batch (initial_inventory > 0) must have day 1 available as
+    # a start day even though it's within the (otherwise blocking) unavailable_periods window.
+    product = Product("batch")
+    source = MaturationSource("s1", Location(0.0, 0.0); capacity=100, unavailable_periods=5)
+    add_product!(source, product; initial_value=90.0, maturation_rate=10.0, target_value=100.0,
+                                  acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
+                                  extended_deviation_under=0.1, extended_deviation_over=0.1,
+                                  initial_inventory=100.0)
+
+    triples = SupplyChainOptimization.feasible_exits(source, product, 1:10, 1:10)
+    any(u == 1 for (u, t, zone) in triples)
+end
+
+@test_throws ArgumentError begin
+    sc = SupplyChain(20)
+    product = Product("batch")
+    other_product = Product("unregistered")
+    add_product!(sc, product)
+
+    source = MaturationSource("s1", Location(0.0, 0.0); capacity=100)
+    add_product!(source, other_product; initial_value=0.0, maturation_rate=10.0, target_value=100.0,
+                                        acceptable_deviation_under=0.1, acceptable_deviation_over=0.1)
+    add_maturation_source!(sc, source)
+
+    sink = QuotaSink("k1", Location(0.0, 0.0))
+    add_product!(sink, product; quota=100.0)
+    add_quota_sink!(sc, sink)
+
+    create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0)
+end
+
+# --- solved instances ---
+
+# A single source/sink, a single delivery day: fully hand-computable. distance=1, cost_per_km=1,
+# capacity=100 -> shipping costs 100; not shipping costs the quota shortfall penalty (100 units *
+# underproduction_unit_penalty=5 -> 500), so the optimizer should always prefer to ship. Among
+# feasible ship durations (only 8 or 9, since the single delivery day t=10 bounds u<10), duration 9
+# (u=1) lands exactly at the acceptable boundary (value=90, zone 0, zero deviation penalty) and
+# strictly dominates duration 8's zone-1 (penalized) option at the same transport cost.
+@test begin
+    sc = SupplyChain(20)
+    product = Product("batch")
+    add_product!(sc, product)
+
+    source = MaturationSource("s1", Location(0.0, 0.0); capacity=100)
+    add_product!(source, product; initial_value=0.0, maturation_rate=10.0, target_value=100.0,
+                                  acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
+                                  extended_deviation_under=0.1, extended_deviation_over=0.1,
+                                  underrun_unit_penalty=1.0, overrun_unit_penalty=1.0)
+    add_maturation_source!(sc, source)
+
+    sink = QuotaSink("k1", Location(0.0, 0.0))
+    add_product!(sink, product; quota=100.0, underproduction_unit_penalty=5.0, overproduction_unit_penalty=5.0)
+    add_quota_sink!(sc, sink)
+
+    m = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0,
+                                           distance=(a, b) -> 1.0, is_delivery_day=t -> t == 10)
+    JuMP.optimize!(m)
+    sc.optimization_model = m
+
+    schedule = get_maturation_schedule(sc, source, product)
+
+    termination_status(m) == OPTIMAL &&
+        objective_value(m) ≈ 100.0 &&
+        schedule.start_day == 1 &&
+        schedule.ship_day == 10 &&
+        schedule.sink == sink &&
+        get_quota_shortfall(sc, sink, product, 10) ≈ 0.0 &&
+        get_quota_excess(sc, sink, product, 10) ≈ 0.0
+end
+
+# Two sources, each half the quota: both must ship (on the same day, since it's the only
+# delivery day) for the quota to be met without penalty - verifies constraint (8) sums shipments
+# from every source, and constraints (9)/(11) still let each source ship independently at most
+# once.
+@test begin
+    sc = SupplyChain(20)
+    product = Product("batch")
+    add_product!(sc, product)
+
+    for name in ("s1", "s2")
+        source = MaturationSource(name, Location(0.0, 0.0); capacity=50)
+        add_product!(source, product; initial_value=0.0, maturation_rate=10.0, target_value=100.0,
+                                      acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
+                                      extended_deviation_under=0.1, extended_deviation_over=0.1)
+        add_maturation_source!(sc, source)
+    end
+
+    sink = QuotaSink("k1", Location(0.0, 0.0))
+    add_product!(sink, product; quota=100.0, underproduction_unit_penalty=5.0, overproduction_unit_penalty=5.0)
+    add_quota_sink!(sc, sink)
+
+    m = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=0.1,
+                                           distance=(a, b) -> 1.0, is_delivery_day=t -> t == 10)
+    JuMP.optimize!(m)
+    sc.optimization_model = m
+
+    s1 = first(s for s in sc.maturation_sources if s.name == "s1")
+    s2 = first(s for s in sc.maturation_sources if s.name == "s2")
+    schedule1 = get_maturation_schedule(sc, s1, product)
+    schedule2 = get_maturation_schedule(sc, s2, product)
+
+    termination_status(m) == OPTIMAL &&
+        !isnothing(schedule1) && !isnothing(schedule2) &&
+        schedule1.ship_day == 10 && schedule2.ship_day == 10 &&
+        get_quota_shortfall(sc, sink, product, 10) ≈ 0.0 &&
+        get_quota_excess(sc, sink, product, 10) ≈ 0.0
+end
+
+# A source with an in-progress batch (initial_inventory > 0) must ship it during the horizon
+# (constraint 13), even though unavailable_periods would otherwise block it from starting.
+@test begin
+    sc = SupplyChain(20)
+    product = Product("batch")
+    add_product!(sc, product)
+
+    source = MaturationSource("s1", Location(0.0, 0.0); capacity=100, unavailable_periods=15)
+    add_product!(source, product; initial_value=90.0, maturation_rate=10.0, target_value=100.0,
+                                  acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
+                                  extended_deviation_under=0.1, extended_deviation_over=0.1,
+                                  initial_inventory=100.0)
+    add_maturation_source!(sc, source)
+
+    sink = QuotaSink("k1", Location(0.0, 0.0))
+    add_product!(sink, product; quota=100.0, underproduction_unit_penalty=1000.0, overproduction_unit_penalty=1000.0)
+    add_quota_sink!(sc, sink)
+
+    m = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0, distance=(a, b) -> 1.0)
+    JuMP.optimize!(m)
+    sc.optimization_model = m
+
+    schedule = get_maturation_schedule(sc, source, product)
+
+    termination_status(m) == OPTIMAL && !isnothing(schedule) && schedule.start_day == 1
+end
+
+end

--- a/test/MaturationScheduling.jl
+++ b/test/MaturationScheduling.jl
@@ -9,31 +9,36 @@
     source = MaturationSource("s1", Location(0.0, 0.0); capacity=100)
     add_product!(source, product; initial_value=0.0, maturation_rate=10.0, target_value=100.0,
                                   acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
-                                  extended_deviation_under=0.1, extended_deviation_over=0.1)
+                                  extended_deviation_under=0.1, extended_deviation_over=0.1,
+                                  underrun_unit_penalty=2.0, overrun_unit_penalty=3.0)
 
-    SupplyChainOptimization.maturation_zone(source, product, 7) === nothing &&   # value=70, below even the extended range
-    SupplyChainOptimization.maturation_zone(source, product, 8) == 1 &&   # value=80, sellable underrun
-    SupplyChainOptimization.maturation_zone(source, product, 9) == 0 &&   # value=90, ideal (boundary)
-    SupplyChainOptimization.maturation_zone(source, product, 10) == 0 &&  # value=100, ideal
-    SupplyChainOptimization.maturation_zone(source, product, 11) == 0 &&  # value=110, ideal (boundary)
-    SupplyChainOptimization.maturation_zone(source, product, 12) == 2 &&  # value=120, sellable overrun
-    SupplyChainOptimization.maturation_zone(source, product, 13) === nothing  # value=130, unsellable
+    !SupplyChainOptimization.is_feasible_duration(source, product, 7) &&   # value=70, below even the extended range
+    SupplyChainOptimization.is_feasible_duration(source, product, 8) &&   # value=80, sellable underrun
+    SupplyChainOptimization.get_duration_penalty(source, product, 8) ≈ 2.0 * abs(100.0 - 80.0) &&
+    SupplyChainOptimization.is_feasible_duration(source, product, 9) &&   # value=90, ideal (boundary)
+    SupplyChainOptimization.get_duration_penalty(source, product, 9) == 0.0 &&
+    SupplyChainOptimization.is_feasible_duration(source, product, 10) &&  # value=100, ideal
+    SupplyChainOptimization.get_duration_penalty(source, product, 10) == 0.0 &&
+    SupplyChainOptimization.is_feasible_duration(source, product, 11) &&  # value=110, ideal (boundary)
+    SupplyChainOptimization.is_feasible_duration(source, product, 12) &&  # value=120, sellable overrun
+    SupplyChainOptimization.get_duration_penalty(source, product, 12) ≈ 3.0 * abs(100.0 - 120.0) &&
+    !SupplyChainOptimization.is_feasible_duration(source, product, 13)  # value=130, unsellable
 end
 
 @test begin
     # feasible_exits should exclude start days at/before unavailable_periods, and only pair a
-    # start day u with ship days t giving a sellable (non-nothing) zone.
+    # start day u with ship days t that are feasible per the source's curve.
     product = Product("batch")
     source = MaturationSource("s1", Location(0.0, 0.0); capacity=100, unavailable_periods=3)
     add_product!(source, product; initial_value=0.0, maturation_rate=10.0, target_value=100.0,
                                   acceptable_deviation_under=0.1, acceptable_deviation_over=0.1,
                                   extended_deviation_under=0.1, extended_deviation_over=0.1)
 
-    triples = SupplyChainOptimization.feasible_exits(source, product, 1:5, 1:20)
-    # No triple should ever start at u<=3 (the unavailable/sanitation period).
-    all(u > 3 for (u, t, zone) in triples) &&
-        (4, 13, 0) in triples &&   # u=4, duration=9 -> value=90 -> zone 0 (ideal, boundary)
-        (4, 12, 1) in triples      # u=4, duration=8 -> value=80 -> zone 1 (sellable underrun)
+    pairs = SupplyChainOptimization.feasible_exits(source, product, 1:5, 1:20)
+    # No pair should ever start at u<=3 (the unavailable/sanitation period).
+    all(u > 3 for (u, t) in pairs) &&
+        (4, 13) in pairs &&   # u=4, duration=9 -> value=90 -> ideal (boundary)
+        (4, 12) in pairs      # u=4, duration=8 -> value=80 -> sellable underrun
 end
 
 @test begin
@@ -46,8 +51,8 @@ end
                                   extended_deviation_under=0.1, extended_deviation_over=0.1,
                                   initial_inventory=100.0)
 
-    triples = SupplyChainOptimization.feasible_exits(source, product, 1:10, 1:10)
-    any(u == 1 for (u, t, zone) in triples)
+    pairs = SupplyChainOptimization.feasible_exits(source, product, 1:10, 1:10)
+    any(u == 1 for (u, t) in pairs)
 end
 
 @test_throws ArgumentError begin
@@ -171,6 +176,41 @@ end
     schedule = get_maturation_schedule(sc, source, product)
 
     termination_status(m) == OPTIMAL && !isnothing(schedule) && schedule.start_day == 1
+end
+
+# The advanced, fully-custom add_product! form (a classical shelf-life curve: constant value,
+# sellable only within a fixed age window, no partial-quality penalty) works through the full
+# MILP exactly like the linear/%-band form - proving MaturationSource's generalization beyond
+# harvest-scheduling-shaped curves end-to-end, not just at the level of the pure helper
+# functions tested above.
+@test begin
+    sc = SupplyChain(10)
+    product = Product("cheese")
+    add_product!(sc, product)
+
+    source = MaturationSource("cave1", Location(0.0, 0.0); capacity=50)
+    add_product!(source, product,
+                 duration -> 1.0,                # value_function: constant once ready
+                 duration -> 2 <= duration <= 5,  # feasible_duration: sellable ages 2 to 5
+                 duration -> 0.0)                 # duration_penalty: no partial-quality penalty
+    add_maturation_source!(sc, source)
+
+    sink = QuotaSink("shop1", Location(0.0, 0.0))
+    add_product!(sink, product; quota=50.0, underproduction_unit_penalty=10.0, overproduction_unit_penalty=10.0)
+    add_quota_sink!(sc, sink)
+
+    m = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0,
+                                           distance=(a, b) -> 1.0, is_delivery_day=t -> t == 6)
+    JuMP.optimize!(m)
+    sc.optimization_model = m
+
+    schedule = get_maturation_schedule(sc, source, product)
+
+    termination_status(m) == OPTIMAL &&
+        objective_value(m) ≈ 50.0 &&
+        !isnothing(schedule) &&
+        schedule.ship_day == 6 &&
+        2 <= schedule.ship_day - schedule.start_day <= 5
 end
 
 end

--- a/test/PaperReplication.jl
+++ b/test/PaperReplication.jl
@@ -120,6 +120,13 @@ end
     m = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=transport_cost_per_distance,
                                            distance=_euclidean_km, is_start_day=is_start_day, is_delivery_day=is_delivery_day)
     set_silent(m)
+    # A hard time limit is not just courtesy here: once transport cost stopped being trivially
+    # dominated (see above), this instance became genuinely hard for HiGHS's B&B, and one CI run
+    # left unbounded churned for over two hours before HiGHS's own RINS/RENS sub-MIP heuristics
+    # segfaulted (a HiGHS-internal crash, not a bug in this package's model). Bounding the solve
+    # avoids both the multi-hour CI run and, empirically, the crash - HiGHS returns its best
+    # incumbent (has_values may still be true under TIME_LIMIT).
+    set_attribute(m, "time_limit", 60.0)
     JuMP.optimize!(m)
     sc.optimization_model = m
 

--- a/test/PaperReplication.jl
+++ b/test/PaperReplication.jl
@@ -1,0 +1,135 @@
+using Dates
+
+# Reproduces the instance-generation recipe of Section 6.1 of Gbéya, Darvish, Renaud and Coelho
+# (2026), "Integrated Poultry Production-Distribution Optimization", CIRRELT-2026-10, using only
+# this package's public, generic constructs (MaturationSource, QuotaSink,
+# create_maturation_scheduling_model) - not a poultry-specific code path. Every parameter below
+# is taken directly from the paper's own text; two points aren't fully pinned down there and are
+# called out explicitly rather than silently guessed:
+#   1. Day 1 of the horizon is assumed to be a Monday (the paper doesn't say) for the
+#      Wednesday/Saturday/Sunday exclusions used to build U and V.
+#   2. The single-slaughterhouse quota derivation ("multiply the average available capacity per
+#      delivery day by a factor randomly selected from (0.1, 0.8); if the result exceeds the
+#      maximum farm capacity, it is set as the quota; otherwise a random number between 0.1 and
+#      0.5 is applied to adjust it") is reconstructed from prose, not a formula, and the second
+#      branch in particular is ambiguous about direction; this uses the closest faithful reading
+#      while still enforcing the paper's own explicit requirement ("the quota must exceed the
+#      farm capacities").
+# Since a different random draw was used, this does not - and does not claim to - reproduce the
+# paper's own reported figures exactly (which aren't available from this session's copy of the
+# paper past Section 6.2 anyway). What it does demonstrate is that the same instance-generation
+# recipe, expressed purely through public MaturationSource/QuotaSink/
+# create_maturation_scheduling_model calls, produces a feasible, sensibly-decomposed solution
+# directly comparable in *structure* to the paper's own Figure 2 (OF = OF_d + OF_w + OF_q+ + OF_q-).
+function _paper_instance(num_farms::Int, num_sinks::Int, weeks::Int)
+    horizon = weeks * 7
+    sc = SupplyChain(horizon)
+    bird = Product("bird")
+    add_product!(sc, bird)
+
+    delta_under, delta_over = 0.1, 0.1
+    xi_under, xi_over = 0.05, 0.05
+    W = 22500.0     # target weight, dg
+    phi = 380.0     # initial weight, dg
+    g1, g2 = 0.0007, 0.001
+
+    day_of_week(t) = (t - 1) % 7   # 0=Mon, ..., 5=Sat, 6=Sun (day 1 assumed Monday - see header)
+    is_start_day(t) = !(day_of_week(t) in (2, 5, 6))   # exclude Wed, Sat, Sun
+    is_delivery_day(t) = !(day_of_week(t) in (5, 6))   # exclude Sat, Sun
+
+    v_start_candidate = ceil(Int, 7 * weeks / 2.5)
+    v_start = first(t for t in v_start_candidate:horizon if is_delivery_day(t))
+    is_paper_delivery_day(t) = t >= v_start && is_delivery_day(t)
+    min_v = v_start
+
+    alpha = (W * (1 - delta_under - xi_under) - phi) / min_v
+    beta = (W * (1 + delta_over + xi_over) - phi) / min_v
+
+    farms_in_cleaning = Set(_random_sample_indices(num_farms, round(Int, 0.1 * num_farms)))
+
+    for f in 1:num_farms
+        capacity = Float64(rand(4000:32000))
+        growth_rate = Float64(rand(ceil(Int, alpha):floor(Int, beta)))
+        unavailable = f in farms_in_cleaning ? rand(1:max(weeks - 1, 1)) : 0
+        farm = MaturationSource("farm$f", Location(rand(0:270), rand(0:270)); capacity=capacity, unavailable_periods=unavailable)
+        add_product!(farm, bird; initial_value=phi, maturation_rate=growth_rate, target_value=W,
+                                 acceptable_deviation_under=delta_under, acceptable_deviation_over=delta_over,
+                                 extended_deviation_under=xi_under, extended_deviation_over=xi_over,
+                                 underrun_unit_penalty=g1, overrun_unit_penalty=g2)
+        add_maturation_source!(sc, farm)
+    end
+
+    total_capacity = sum(f.capacity for f in sc.maturation_sources)
+    max_capacity = maximum(f.capacity for f in sc.maturation_sources)
+    num_delivery_days = count(is_paper_delivery_day, 1:horizon)
+    average_capacity_per_delivery_day = total_capacity / num_delivery_days
+
+    # 50/30/20-style geometric split for multi-sink instances, single sink gets the whole quota.
+    raw_shares = [0.6^(i - 1) for i in 1:num_sinks]
+    shares = raw_shares ./ sum(raw_shares)
+
+    for (i, share) in enumerate(shares)
+        candidate = average_capacity_per_delivery_day * share * (0.1 + rand() * 0.7)
+        quota = candidate > max_capacity * share ? candidate : max_capacity * share * (1.1 + rand() * 0.4)
+        sink = QuotaSink("slaughterhouse$i", Location(rand(0:50), rand(0:150)))
+        add_product!(sink, bird; quota=round(quota), underproduction_unit_penalty=1.0, overproduction_unit_penalty=1.0)
+        add_quota_sink!(sc, sink)
+    end
+
+    return sc, is_start_day, is_paper_delivery_day
+end
+
+function _random_sample_indices(n, k)
+    pool = collect(1:n)
+    k = min(k, n)
+    selected = Int[]
+    for _ in 1:k
+        index = rand(1:length(pool))
+        push!(selected, pool[index])
+        deleteat!(pool, index)
+    end
+    return selected
+end
+
+# Plane-coordinate Euclidean distance, rounded to the nearest km - the paper's farms/
+# slaughterhouses are placed on an abstract 270x270 / 50x150 grid, not real latitude/longitude,
+# so haversine (spherical) doesn't apply; distance is a plain function argument to
+# create_maturation_scheduling_model precisely so callers can supply whatever geometry fits
+# their own data, without the model itself assuming anything about it.
+function _euclidean_km(location1::Location, location2::Location)
+    return round(sqrt((location1.latitude - location2.latitude)^2 + (location1.longitude - location2.longitude)^2))
+end
+
+@testset "PaperReplication" begin
+
+@test begin
+    num_farms, num_sinks, weeks = 60, 1, 6
+    sc, is_start_day, is_delivery_day = _paper_instance(num_farms, num_sinks, weeks)
+
+    m = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0,
+                                           distance=_euclidean_km, is_start_day=is_start_day, is_delivery_day=is_delivery_day)
+    set_silent(m)
+    JuMP.optimize!(m)
+    sc.optimization_model = m
+
+    solved = has_values(m)
+
+    if solved
+        of = get_total_costs(sc)
+        of_d = get_total_transportation_costs(sc)
+        of_w = get_total_deviation_costs(sc)
+        of_q_plus = get_total_overproduction_costs(sc)
+        of_q_minus = get_total_underproduction_costs(sc)
+
+        println("--- Paper replication (IPPDP-$num_farms-$num_sinks-$weeks style instance) ---")
+        println("OF=$of (OF_d=$of_d, OF_w=$of_w, OF_q+=$of_q_plus, OF_q-=$of_q_minus)")
+        println("status=$(termination_status(m)), consistent with breakdown: $(isapprox(of, of_d + of_w + of_q_plus + of_q_minus; rtol=1e-6))")
+    end
+
+    # Structural checks, not a numeric match to the paper's own (unreproducible, different-seed)
+    # figures: the instance must be solvable, and the reported total must equal its own reported
+    # components, exactly like the paper's Figure 2.
+    solved && isapprox(get_total_costs(sc), get_total_transportation_costs(sc) + get_total_deviation_costs(sc) + get_total_quota_deviation_costs(sc); rtol=1e-6)
+end
+
+end

--- a/test/PaperReplication.jl
+++ b/test/PaperReplication.jl
@@ -106,7 +106,18 @@ end
     num_farms, num_sinks, weeks = 60, 1, 6
     sc, is_start_day, is_delivery_day = _paper_instance(num_farms, num_sinks, weeks)
 
-    m = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=1.0,
+    # transport_cost_per_distance=1.0 (matching the underrun/overrun quota penalties' scale of
+    # $1/bird) was tried first and made every instance degenerate: a bird's transport cost is
+    # distance * transport_cost_per_distance * capacity, and on this 270x270 grid distances run
+    # into the hundreds, so shipping anywhere cost far more per bird than just eating the $1/bird
+    # quota underproduction penalty - the solver's global optimum was to never ship a single
+    # batch (OF_d=OF_w=0, all cost dumped into OF_q-). Scaling by the grid's own diagonal
+    # (~382 units) keeps a bird's transport cost below $1 for any farm-sink pair in this instance,
+    # so shipping is never structurally dominated regardless of distance, and the replication
+    # exercises the model's actual start/ship timing and quota trade-offs instead of a trivial
+    # all-zero solution.
+    transport_cost_per_distance = 1.0 / 400.0
+    m = create_maturation_scheduling_model(sc, HiGHS.Optimizer; transport_cost_per_distance=transport_cost_per_distance,
                                            distance=_euclidean_km, is_start_day=is_start_day, is_delivery_day=is_delivery_day)
     set_silent(m)
     JuMP.optimize!(m)
@@ -127,9 +138,12 @@ end
     end
 
     # Structural checks, not a numeric match to the paper's own (unreproducible, different-seed)
-    # figures: the instance must be solvable, and the reported total must equal its own reported
-    # components, exactly like the paper's Figure 2.
-    solved && isapprox(get_total_costs(sc), get_total_transportation_costs(sc) + get_total_deviation_costs(sc) + get_total_quota_deviation_costs(sc); rtol=1e-6)
+    # figures: the instance must be solvable, the reported total must equal its own reported
+    # components (exactly like the paper's Figure 2), and at least one farm must actually ship -
+    # guarding against a regression back to the all-zero-shipment degeneracy described above.
+    solved &&
+        isapprox(get_total_costs(sc), get_total_transportation_costs(sc) + get_total_deviation_costs(sc) + get_total_quota_deviation_costs(sc); rtol=1e-6) &&
+        get_total_transportation_costs(sc) > 0
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ include("UFLlib.jl")
 include("Profits.jl")
 include("GSM.jl")
 include("MaturationScheduling.jl")
+include("Matheuristics.jl")
 
 include("UnitTests.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ include("Profits.jl")
 include("GSM.jl")
 include("MaturationScheduling.jl")
 include("Matheuristics.jl")
+include("MatheuristicBenchmark.jl")
 
 include("UnitTests.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ include("GSM.jl")
 include("MaturationScheduling.jl")
 include("Matheuristics.jl")
 include("MatheuristicBenchmark.jl")
+include("PaperReplication.jl")
 
 include("UnitTests.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ include("Inventory.jl")
 include("UFLlib.jl")
 include("Profits.jl")
 include("GSM.jl")
+include("MaturationScheduling.jl")
 
 include("UnitTests.jl")
 


### PR DESCRIPTION
## Summary

Implements the integrated poultry production-distribution problem (IPPDP) of Gbéya, Darvish,
Renaud and Coelho (2026), "Integrated Poultry Production-Distribution Optimization",
CIRRELT-2026-10, as a generic maturation-scheduling model on top of the new `MaturationSource`
and `QuotaSink` node types from
[SupplyChainModeling.jl#10](https://github.com/SupplyChef/SupplyChainModeling.jl/pull/10) —
plus a generic MILP matheuristic engine that works on both this model and the package's
existing `create_network_model`.

### `create_maturation_scheduling_model` (`src/MaturationScheduling.jl`)

Builds the paper's exact MILP formulation (Section 4): binary `y[b,p,u,t]` (batch `b` of
product `p` starts maturing at `u`, ships at `t`) and `r[b,p,s,t]` (batch `b` ships to sink `s`
at `t`) variables, quota-deviation variables `q_plus`/`q_minus`, and constraints (8)-(13)
covering all-in-all-out sourcing, feasible start/ship windows, changeover/unavailable periods,
single-sink shipment, and quota balance. Feasibility and penalty of a given hold duration are
read directly off each `MaturationSource`'s pluggable curve via `is_feasible_duration`/
`get_duration_penalty` (`src/Modeling.jl`) — the model has no poultry-specific weight-band
logic; it only calls the generic curve functions the node exposes.

The objective is built from named expressions so callers can query cost breakdowns after
solving, mirroring the paper's own `OF = OF_d + OF_w + OF_q+ + OF_q-` decomposition:
`total_transportation_costs`, `total_deviation_costs`, `total_overproduction_costs`,
`total_underproduction_costs`, `total_quota_deviation_costs` (= over + under), and
`total_costs` (the actual objective, = transportation + deviation + quota-deviation).
`get_total_costs`/`get_total_transportation_costs` from the existing `Querying.jl` work
unchanged since the expression names match.

`integer_quota_deviation::Bool=true` controls whether `q_plus`/`q_minus` are integer or
continuous — added after a real bug was found: with non-integer `capacity`/`quota` inputs,
forcing integer deviation variables can make constraint (8) infeasible by construction. Callers
with fractional capacities/quotas should pass `integer_quota_deviation=false`.

Query functions: `get_maturation_schedule`, `get_quota_shortfall`, `get_quota_excess`,
`get_total_deviation_costs`, `get_total_overproduction_costs`, `get_total_underproduction_costs`,
`get_total_quota_deviation_costs`. `optimize_maturation_schedule!` is the one-call convenience
wrapper.

### `matheuristic_optimize!` (`src/Matheuristics.jl`)

A generic large-neighborhood-search / RINS-style matheuristic that operates on **any** JuMP
model produced by this package (tested against both `create_network_model` and
`create_maturation_scheduling_model`) — it works purely off the model's variables and bounds,
with no knowledge of what problem it's solving. Supports two neighborhood strategies:
`:fix` (randomly fix a fraction of integer/binary variables to their incumbent value each
iteration) and `:local_branching` (Fischetti & Lodi 2003 local-branching cut). Warm-starts each
iteration from the best incumbent found so far via `JuMP.set_start_value`, and warm-starts the
final full-model re-solve from the best neighborhood solution too.

**Honest benchmark results** (`test/MatheuristicBenchmark.jl`, run against HiGHS): on both a
60-farm/1-sink and a 200-farm/3-sink `create_maturation_scheduling_model` instance, the
matheuristic does **not** measurably improve on HiGHS's own direct solve — HiGHS proves global
optimality quickly on both scales tested, so there's no gap left for the matheuristic to close.
It also does not regress solution quality on any tested model. Whether it would help on harder
instances (e.g., large capacitated facility-location problems, or against a different solver
like Gurobi) was explicitly scoped out of this PR at the user's request and is not claimed here
either way — the benchmark reports what was actually measured, not a projection.

### Paper replication (`test/PaperReplication.jl`)

Reproduces the paper's Section 6.1 instance-generation recipe (farm count, capacity/growth-rate
ranges, weight-band deviation parameters, quota derivation, Wednesday/Saturday/Sunday exclusion
calendar) using only the public `MaturationSource`/`QuotaSink`/`create_maturation_scheduling_model`
API — no poultry-specific code path. Since the paper uses a different random seed than this
test (and the exact quota-derivation formula is reconstructed from prose, not a published
formula — see the test file's header comment for the two specific ambiguities), this does not
claim to numerically reproduce the paper's own figures. What it does verify is that the same
recipe, expressed generically, produces a feasible solution whose reported cost decomposes
exactly as `OF = OF_d + OF_w + OF_q+ + OF_q-`, directly comparable in *structure* to the
paper's own Figure 2.

An earlier version of this test priced transport at the same $1/bird scale as the quota
underproduction penalty; since distances on the instance's 270x270 grid run into the hundreds,
that made shipping anywhere strictly worse than eating the quota penalty outright, so every
run degenerated to zero shipments (`OF_d=OF_w=0`, all cost dumped into `OF_q-`). Fixed by
scaling `transport_cost_per_distance` to the grid's own diagonal, with a
`get_total_transportation_costs(sc) > 0` check guarding against regressing back to that
degenerate case.

## Documentation

`docs/src/maturation scheduling.md` and `docs/src/matheuristics.md` are new, with a worked
poultry example, a second fully non-poultry example (shelf-life produce inventory, using only
the custom-curve `add_product!` form), and an explicit mapping table from the generic
constructs (`MaturationSource`, `capacity`, `value_function`, `feasible_duration`,
`duration_penalty`, `changeover_periods`, `QuotaSink`, `quota`) to several concrete domains
(poultry, cheese aging, fresh produce). `docs/src/reference.md` and `docs/make.jl` updated
accordingly.

## Dependency note

[SupplyChainModeling.jl#10](https://github.com/SupplyChef/SupplyChainModeling.jl/pull/10) (the
`MaturationSource`/`QuotaSink` companion change) has merged to `main`. `Project.toml`'s
`[sources]`, `.github/workflows/ci.yml`, and `docs/make.jl` now pin `SupplyChainModeling` to
its `main` branch (rather than a registry release), matching this repo's existing pattern for
tracking pre-release `SupplyChainModeling` features.

## Testing

`test/MaturationScheduling.jl`, `test/Matheuristics.jl`, `test/MatheuristicBenchmark.jl`, and
`test/PaperReplication.jl` are all new and included from `test/runtests.jl`. All existing tests
are unchanged and passing.
