### PR TITLE
Make PlotlyJS/Plots weak dependencies (fixes JSON version conflict)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,24 @@
 name = "SupplyChainOptimization"
 uuid = "785807e5-a5cf-4c87-8002-234621def379"
 authors = ["SupplyChef <47842426+SupplyChef@users.noreply.github.com>"]
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 SupplyChainModeling = "8a0b78ce-42db-494b-a45c-80b287de1a3d"
+
+[weakdeps]
+PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+
+[extensions]
+SupplyChainOptimizationPlotlyJSExt = "PlotlyJS"
+SupplyChainOptimizationPlotsExt = ["PlotlyJS", "Plots"]
 
 [compat]
 Dates = "1.10"
@@ -26,15 +32,7 @@ StatsBase = "0.34"
 SupplyChainModeling = "0.2, 0.3, 0.4"
 julia = "1.10"
 
-# TEMPORARY: the maximum_units/overflow_unit_cost support this depends on has
-# already merged to SupplyChainModeling's main (now at 0.4.0 - 0.4.0 only
-# added MaturationSource/QuotaSink, additive and unused here, so this is
-# just riding along), but isn't published to a registry yet, so point at
-# main directly rather than a moving feature branch. Remove this section
-# once a registry release exists - and keep the compat bound above in sync
-# with whatever version main currently declares in the meantime, or
-# [sources]-based resolution fails outright (main's declared version must
-# satisfy this bound; unlike a plain `Pkg.add(rev=...)`, [sources] does not
-# bypass compat checking).
-[sources]
-SupplyChainModeling = {url = "https://github.com/SupplyChef/SupplyChainModeling.jl", rev = "main"}
+# SupplyChainModeling is a normal registered dependency (General, v0.4.0+)
+# as of 2026-09-02 - no [sources] override needed. It briefly needed one
+# (the registry had drifted behind `main`) - see PLAN.md in ExcelAtRetail.jl
+# and this repo's git history around that date if that situation recurs.

--- a/ext/SupplyChainOptimizationPlotlyJSExt.jl
+++ b/ext/SupplyChainOptimizationPlotlyJSExt.jl
@@ -1,0 +1,348 @@
+# Package extension: loaded automatically once PlotlyJS is `using`'d
+# alongside SupplyChainOptimization (see Project.toml's
+# [weakdeps]/[extensions] and src/Visualization.jl's stub declarations for
+# why this split exists - PlotlyJS 0.18.x needs an old JSON.jl that's
+# incompatible with anything needing modern JSON.jl, e.g. Oxygen.jl).
+#
+# Everything here only needs PlotlyJS (not Plots) - movie_network is the
+# one function that also needs Plots.Animation/mp4, so it lives in the
+# separate SupplyChainOptimizationPlotsExt instead, triggered by both
+# packages together. That mirrors test/Project.toml's existing shape
+# (PlotlyJS only, no Plots - movie_network was already untested).
+#
+# This is a straight move of most of what used to be src/Visualization.jl
+# (except get_financials, which moved to Querying.jl since it never touched
+# PlotlyJS/Plots, and movie_network, split into the other extension) -
+# method bodies are unchanged, just relocated and qualified against the
+# parent module since this lives in a separate module now.
+module SupplyChainOptimizationPlotlyJSExt
+
+using SupplyChainOptimization
+using SupplyChainModeling
+using PlotlyJS
+using JuMP
+
+"""
+    plot_inventory(supply_chain, storage, product)
+
+Plots the amount of inventory of a product on-hand at a storage location at the beginning of each period.
+"""
+function SupplyChainOptimization.plot_inventory(supply_chain, storage, product)
+    return Plot(scatter(;x=1:supply_chain.horizon, y=[SupplyChainOptimization.get_inventory_at_end(supply_chain, storage, product, t) for t in 1:supply_chain.horizon], mode="lines+markers"))
+end
+
+"""
+    plot_network(supply_chain, period=1; geography="usa", showlegend=true)
+
+Plots the nodes of the supply chain on a map.
+
+The geography must be one of: "world" | "usa" | "europe" | "asia" | "africa" | "north america" | "south america".
+"""
+function SupplyChainOptimization.plot_network(supply_chain, period=1;
+                      geography="usa",
+                      showlegend=true,
+                      title="Supply chain network",
+                      excluded_nodes=[],
+                      groups=[(supply_chain.storages, "storage", "square", "blue", 1.0),
+                              (supply_chain.plants, "plant", "triangle-up", "red", 1.0)])
+    traces = AbstractTrace[]
+
+    for group in groups
+        first = true
+        for element in group[1]
+            if in(element, excluded_nodes)
+                continue
+            end
+            if SupplyChainOptimization.is_opened(supply_chain, element, period)
+                push!(traces,
+                    scattergeo(;lat=[element.location.latitude],
+                                lon=[element.location.longitude],
+                                legendgroup=group[2],
+                                showlegend=first,
+                                hoverinfo="text",
+                                text="$(element.name) - $(sum(SupplyChainOptimization.get_shipments(supply_chain, element, p, period) for p in supply_chain.products))",
+                                name=group[2],
+                                mode="markers",
+                                marker_symbol=group[3],
+                                marker_size=10,
+                                marker_color=group[4],
+                                marker_opacity=group[5])
+                )
+                first = false
+            end
+        end
+    end
+
+    first = true
+    for supplier in supply_chain.suppliers
+        if in(supplier, excluded_nodes)
+            continue
+        end
+        if sum(SupplyChainOptimization.get_shipments(supply_chain, supplier, p, period) for p in supply_chain.products) > 1e-10
+            push!(traces,
+                scattergeo(;lat=[supplier.location.latitude],
+                            lon=[supplier.location.longitude],
+                            legendgroup="supplier",
+                            showlegend=first,
+                            hoverinfo="text",
+                            text="$(supplier.name)",
+                            name="suppliers",
+                            mode="markers",
+                            marker_symbol="circle",
+                            marker_size=10,
+                            marker_color="yellow")
+            )
+            first = false
+        end
+    end
+
+    for (i, customer) in enumerate(supply_chain.customers)
+        push!(traces,
+            scattergeo(;lat=[customer.location.latitude],
+                        lon=[customer.location.longitude],
+                        legendgroup="customer",
+                        showlegend=(i==1),
+                        hoverinfo="text",
+                        text="$(customer.name) - $(sum(SupplyChainOptimization.get_shipments(supply_chain, customer, p, period) for p in supply_chain.products))",
+                        name="customers",
+                        mode="markers",
+                        marker_symbol="circle",
+                        marker_color="green",
+                        marker_opacity=0.35)
+        )
+    end
+
+    geo = attr(scope=geography,
+                showland=true,)
+
+    layout = Layout(;title=title, showlegend=showlegend, geo=geo)
+    return Plot(traces, layout)
+end
+
+"""
+    plot_costs(supply_chain)
+
+Plots the costs of operating the supply chain.
+"""
+function SupplyChainOptimization.plot_costs(supply_chain)
+    trace1 = bar(;x=1:supply_chain.horizon,
+                 y=[value(supply_chain.optimization_model[:total_fixed_costs_per_period][t]) for t in 1:supply_chain.horizon],
+                 name="Fixed Costs")
+    trace2 = bar(;x=1:supply_chain.horizon,
+                 y=[value(supply_chain.optimization_model[:total_transportation_costs_per_period][t]) for t in 1:supply_chain.horizon],
+                 name="Transportation Costs")
+    trace3 = bar(;x=1:supply_chain.horizon,
+                 y=[value(supply_chain.optimization_model[:total_opening_costs_per_period][t]) for t in 1:supply_chain.horizon],
+                 name="Opening Costs")
+    trace4 = bar(;x=1:supply_chain.horizon,
+                 y=[value(supply_chain.optimization_model[:total_costs_per_period][t])  -
+                    (value(supply_chain.optimization_model[:total_fixed_costs_per_period][t]) +
+                     value(supply_chain.optimization_model[:total_transportation_costs_per_period][t]) +
+                     value(supply_chain.optimization_model[:total_opening_costs_per_period][t])
+                     ) for t in 1:supply_chain.horizon],
+                 name="Other Costs")
+
+    layout = Layout(;barmode="stack",
+                    xaxis_title="Period", xaxis_tick0=1, xaxis_dtick=1, xaxis_rangemode="nonnegative",
+                    yaxis_title="Cost (\$)")
+    Plot([trace1, trace2, trace3, trace4], layout)
+end
+
+"""
+    plot_financials(supply_chain; max_time=supply_chain.horizon)
+
+Plots the financial results of operating the supply chain.
+"""
+function SupplyChainOptimization.plot_financials(supply_chain; max_time=supply_chain.horizon, title="Supply chain financials")
+    financials = SupplyChainOptimization.get_financials(supply_chain; max_time=max_time)
+
+    plot([scatter(;x=financials.Horizon, y=financials.Revenues, name="revenues"),
+        scatter(;x=financials.Horizon, y=financials.Costs, name="costs"),
+        scatter(;x=financials.Horizon, y=financials.Profits, name="profits"),
+        scatter(;x=financials.Horizon, y=financials.Cumulative_Profits, name="cumulative_profits"),
+        scatter(;x=financials.Horizon, y=financials.Transportation_Costs, name="transportation costs"),
+        scatter(;x=financials.Horizon, y=financials.Holding_Costs, name="holding costs"),
+        scatter(;x=financials.Horizon, y=financials.Buying_Costs, name="buying costs"),
+        scatter(;x=financials.Horizon, y=financials.Warehouses_Fixed_Costs, name="warehouse fixed costs"),
+        scatter(;x=financials.Horizon, y=financials.Opening_Costs, name="opening costs"),
+        scatter(;x=financials.Horizon, y=financials.Closing_Costs, name="closing costs"),
+        ],
+        Layout(;title=title))
+end
+
+"""
+    plot_flows(supply_chain, period=1; geography="usa", showlegend=true)
+
+Plots the flows of products in the supply chain.
+"""
+function SupplyChainOptimization.plot_flows(supply_chain, period=1; geography="usa", showlegend=true, excluded_origins=[], origin_colors = Dict{Node, String}())
+
+    colors = ["red", "blue", "green", "orange", "black", "purple"]
+
+    color_index = length(origin_colors)
+
+    traces = AbstractTrace[]
+    for l in supply_chain.lanes #sort(collect(supply_chain.lanes), by=l->string(l.origin.location.name, l.destination.location.name))
+        if in(l.origin, excluded_origins)
+            continue
+        end
+        for d in l.destinations
+            if sum(SupplyChainOptimization.get_shipments(supply_chain, l, d, p, period) for p in supply_chain.products) > 2e-10
+                if l.origin in keys(origin_colors)
+                    color = origin_colors[l.origin]
+                else
+                    color_index = mod1(color_index + 1, length(colors))
+                    color = colors[color_index]
+                    push!(origin_colors, l.origin => color)
+                end
+
+                push!(traces,
+                    scattergeo(;lat=[l.origin.location.latitude, d.location.latitude],
+                                lon=[l.origin.location.longitude, d.location.longitude],
+                                hoverinfo="text",
+                                text="$(l.origin.location.name) - $(d.location.name)",
+                                name="$(l.origin.location.name) - $(d.location.name)",
+                                mode="lines",
+                                line_color=color)
+                )
+            end
+        end
+    end
+
+    geo = attr(scope=geography,
+                showland=true,)
+
+    layout = Layout(;title="Supply chain flows", showlegend=showlegend, geo=geo)
+    Plot(traces, layout)
+end
+
+# Shared by animate_network/animate_flows below: given the per-period Plot
+# vector `ps` (one plot_network/plot_flows result per period), builds the
+# frame/slider/play-pause-button/layout scaffolding for a Plotly time
+# animation. The two callers differ only in how `ps` itself is built.
+function _animate(ps, supply_chain; geography, showlegend)
+    #generate the initial frame
+    trace = [scattergeo() for i in 1:length(getfield(ps[supply_chain.horizon], :data))]
+
+    #store all frames in a vector
+    frames = PlotlyFrame[
+        frame(
+            data = getfield(ps[k], :data),
+            layout = attr(title_text = "Period $k"), #update title
+            name = "frame_$k", #update frame name
+            traces = collect(1:length(getfield(ps[k], :data)))
+        ) for k = 1:supply_chain.horizon
+    ]
+
+    #define the slider for manually viewing the frames
+    sliders_attr = [
+        attr(
+            active = 0,
+            minorticklen = 0,
+            pad_t = 10,
+            steps = [
+                attr(
+                    method = "animate",
+                    label = "Period $k",
+                    args = [
+                        ["frame_$k"], #match the name of the frame again
+                        attr(
+                            mode = "immediate",
+                            transition = attr(duration = 0),
+                            frame = attr(duration = 5, redraw = true),
+                        ),
+                    ],
+                ) for k = 1:supply_chain.horizon
+            ],
+        ),
+    ]
+
+    #define the displaying time per played frame (in milliseconds)
+    dt_frame = 250
+
+    #define the play and pause buttons
+    buttons_attr = [
+        attr(
+            label = "Play",
+            method = "animate",
+            args = [
+                nothing,
+                attr(
+                    fromcurrent = true,
+                    transition = (duration = dt_frame,),
+                    frame = attr(duration = dt_frame, redraw = true),
+                ),
+            ],
+        ),
+        attr(
+            label = "Pause",
+            method = "animate",
+            args = [
+                [nothing],
+                attr(
+                    mode = "immediate",
+                    fromcurrent = true,
+                    transition = attr(duration = dt_frame),
+                    frame = attr(duration = dt_frame, redraw = true),
+                ),
+            ],
+        ),
+    ]
+
+    #layout for the plot
+    layout = Layout(
+        width = 1500,
+        height = 1000,
+        margin_b = 90,
+        # add buttons to play the animation
+        updatemenus = [
+            attr(
+                x = 0.5,
+                y = 0,
+                yanchor = "top",
+                xanchor = "center",
+                showactive = true,
+                direction = "left",
+                type = "buttons",
+                pad = attr(t = 90, r = 10),
+                buttons = buttons_attr,
+            ),
+        ],
+        #add the sliders
+        sliders = sliders_attr,
+
+        showlegend=showlegend,
+        geo = attr(scope=geography,
+                    showland=true,),
+    )
+
+    #save the plot and show it
+    return Plot(trace, layout, frames)
+end
+
+"""
+    animate_network
+
+Creates an animation of the network through time.
+"""
+function SupplyChainOptimization.animate_network(supply_chain;
+                         geography="usa",
+                         showlegend=true,
+                         excluded_nodes=[],
+                         groups=[(supply_chain.storages, "storage", "square", "blue", 1.0), (supply_chain.plants, "plant", "triangle-up", "red", 1.0)])
+    ps = [SupplyChainOptimization.plot_network(supply_chain, i; geography=geography, showlegend=showlegend, excluded_nodes=excluded_nodes, groups=groups) for i in 1:supply_chain.horizon]
+    return _animate(ps, supply_chain; geography=geography, showlegend=showlegend)
+end
+
+"""
+    animate_flows; geography="usa", showlegend=true, excluded_origins=[])
+
+Creates an animation of the product flows through time.
+"""
+function SupplyChainOptimization.animate_flows(supply_chain; geography="usa", showlegend=true, excluded_origins=[])
+    origin_colors = Dict{Node, String}()
+    ps = [SupplyChainOptimization.plot_flows(supply_chain, i; geography=geography, showlegend=showlegend, excluded_origins=excluded_origins, origin_colors=origin_colors) for i in 1:supply_chain.horizon]
+    return _animate(ps, supply_chain; geography=geography, showlegend=showlegend)
+end
+
+end # module

--- a/ext/SupplyChainOptimizationPlotsExt.jl
+++ b/ext/SupplyChainOptimizationPlotsExt.jl
@@ -1,0 +1,43 @@
+# Package extension: loaded automatically once both PlotlyJS and Plots are
+# `using`'d alongside SupplyChainOptimization. Split out from
+# SupplyChainOptimizationPlotlyJSExt because movie_network is the only
+# function that needs Plots (for Animation/mp4) on top of PlotlyJS -
+# everything else only needs PlotlyJS. Keeping it separate means a consumer
+# with just PlotlyJS loaded still gets plot_network/plot_costs/etc.; Plots
+# is only required for this one video-export feature.
+module SupplyChainOptimizationPlotsExt
+
+using SupplyChainOptimization
+using PlotlyJS: savefig
+using Plots: Animation, buildanimation, mp4
+
+"""
+    movie_network
+
+Makes a movie of the network evolution.
+"""
+function SupplyChainOptimization.movie_network(supply_chain, file_path;
+                        geography="usa",
+                        showlegend=true,
+                        excluded_nodes=[],
+                        groups=[(supply_chain.storages, "storage", "square", "blue", 1.0), (supply_chain.plants, "plant", "triangle-up", "red", 1.0)])
+    ps = [SupplyChainOptimization.plot_network(supply_chain, i;
+                        geography=geography,
+                        showlegend=showlegend,
+                        excluded_nodes=excluded_nodes,
+                        groups=groups) for i in 1:supply_chain.horizon]
+
+    mktempdir() do dir
+        fnames = String[]
+        for (i, p) in enumerate(ps)
+            fname = lpad(i, 6, "0") * ".png"
+            push!(fnames, fname)
+            savefig(p, joinpath(dir, fname), width=700, height=500, scale=1)
+        end
+
+        anim = Animation(dir, fnames)
+        mp4(anim, file_path; fps=1)
+    end
+end
+
+end # module

--- a/src/Querying.jl
+++ b/src/Querying.jl
@@ -1,3 +1,5 @@
+using DataFrames
+
 """
     get_total_costs(supply_chain::SupplyChain)
 
@@ -192,4 +194,31 @@ function check(supply_chain)
         !((termination_status(supply_chain.optimization_model) == JuMP.OPTIMAL) || (primal_status(supply_chain.optimization_model) == JuMP.FEASIBLE_POINT) || has_values(supply_chain.optimization_model))
         throw(ErrorException("The optimize_network! function must be called first."))
     end
+end
+
+"""
+    get_financials(supply_chain; max_time=supply_chain.horizon)
+
+Gets the financial results of operating the supply chain.
+
+(Moved here from Visualization.jl: unlike everything else in that file, this
+doesn't touch PlotlyJS/Plots at all, so it stays available without the
+`ext/SupplyChainOptimizationPlotlyJSExt` package extension - see that file
+and Visualization.jl for why the split exists.)
+"""
+function get_financials(supply_chain; max_time=supply_chain.horizon)
+    profits = collect(value.(supply_chain.optimization_model[:total_revenues_per_period]))[1:max_time].-collect(value.(supply_chain.optimization_model[:total_costs_per_period]))[1:max_time]
+    cum_profits = cumsum(profits, dims=1)
+
+    DataFrame((Horizon = 1:max_time,
+               Profits = profits,
+               Cumulative_Profits = cum_profits,
+               Revenues = collect(value.(supply_chain.optimization_model[:total_revenues_per_period]))[1:max_time],
+               Costs = collect(value.(supply_chain.optimization_model[:total_costs_per_period]))[1:max_time],
+               Transportation_Costs = collect(value.(supply_chain.optimization_model[:total_transportation_costs_per_period]))[1:max_time],
+               Holding_Costs = collect(value.(supply_chain.optimization_model[:total_holding_costs_per_period]))[1:max_time],
+               Buying_Costs = collect(value.(supply_chain.optimization_model[:total_buying_costs_per_period]))[1:max_time],
+               Warehouses_Fixed_Costs = [sum(value(supply_chain.optimization_model[:opened][w,t]) * w.fixed_cost for w in supply_chain.storages) for t in 1:max_time],
+               Opening_Costs = collect(value.(supply_chain.optimization_model[:total_opening_costs_per_period]))[1:max_time],
+               Closing_Costs = collect(value.(supply_chain.optimization_model[:total_closing_costs_per_period]))[1:max_time]))
 end

--- a/src/SupplyChainOptimization.jl
+++ b/src/SupplyChainOptimization.jl
@@ -1,16 +1,25 @@
 module SupplyChainOptimization
 
 using SupplyChainModeling
+using Base: Bool, product
+using JuMP
+using HiGHS
 
+# `using JuMP` above has to come before these includes, not after: Optimization.jl's
+# functions use JuMP macros (@variable, @constraint, @objective, ...) in their bodies,
+# and macro expansion happens at parse time (during `include`), unlike ordinary
+# function calls which resolve names lazily at call time. This used to work by
+# accident - Visualization.jl (included just before Optimization.jl) had its own
+# `using JuMP`, which made JuMP's macros available module-wide from that point on.
+# Once Visualization.jl stopped needing JuMP itself (PlotlyJS/Plots became weak
+# deps - see that file and ext/), that accidental ordering broke Optimization.jl's
+# precompilation. Don't reintroduce a `using JuMP` inside one of the included files
+# as a fix - it worked once by luck, not by design.
 include("Modeling.jl")
 include("Querying.jl")
 include("Visualization.jl")
 include("Optimization.jl")
 include("GSM.jl")
-
-using Base: Bool, product
-using JuMP
-using HiGHS
 
 export minimize_cost!,
       maximize_profits!,

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -1,16 +1,27 @@
-using PlotlyJS
-using JuMP
-using DataFrames
-using Plots: Animation, buildanimation, mp4
+# PlotlyJS and Plots are weak dependencies (see Project.toml's
+# [weakdeps]/[extensions]): pulling them in unconditionally made this
+# package unresolvable alongside anything depending on a modern JSON.jl
+# (PlotlyJS 0.18.x needs JSON 0.20-0.21; e.g. Oxygen.jl needs JSON 1.x - no
+# version satisfies both, so any consumer needing both would fail to
+# resolve at all, not just at plot time).
+#
+# The actual implementations live in
+# ext/SupplyChainOptimizationPlotlyJSExt.jl, which Julia loads
+# automatically once both PlotlyJS and Plots are `using`'d alongside this
+# package - no special syntax needed by the caller beyond having both
+# loaded. These are just stub declarations: they keep the names part of
+# this package's own export/API surface and documented, regardless of
+# whether the extension is active. Calling one before both packages are
+# loaded raises a plain `MethodError`.
 
 """
     plot_inventory(supply_chain, storage, product)
 
 Plots the amount of inventory of a product on-hand at a storage location at the beginning of each period.
+
+Requires `PlotlyJS` and `Plots` to be loaded (see this file's top-of-file note).
 """
-function plot_inventory(supply_chain, storage, product)
-    return Plot(scatter(;x=1:supply_chain.horizon, y=[get_inventory_at_end(supply_chain, storage, product, t) for t in 1:supply_chain.horizon], mode="lines+markers"))
-end
+function plot_inventory end
 
 """
     plot_network(supply_chain, period=1; geography="usa", showlegend=true)
@@ -18,361 +29,61 @@ end
 Plots the nodes of the supply chain on a map.
 
 The geography must be one of: "world" | "usa" | "europe" | "asia" | "africa" | "north america" | "south america".
+
+Requires `PlotlyJS` and `Plots` to be loaded (see this file's top-of-file note).
 """
-function plot_network(supply_chain, period=1;
-                      geography="usa",
-                      showlegend=true,
-                      title="Supply chain network",
-                      excluded_nodes=[],
-                      groups=[(supply_chain.storages, "storage", "square", "blue", 1.0),
-                              (supply_chain.plants, "plant", "triangle-up", "red", 1.0)])
-    traces = AbstractTrace[]
-
-    for group in groups
-        first = true
-        for element in group[1]
-            if in(element, excluded_nodes)
-                continue
-            end
-            if is_opened(supply_chain, element, period)
-                push!(traces,
-                    scattergeo(;lat=[element.location.latitude],
-                                lon=[element.location.longitude],
-                                legendgroup=group[2],
-                                showlegend=first,
-                                hoverinfo="text",
-                                text="$(element.name) - $(sum(get_shipments(supply_chain, element, p, period) for p in supply_chain.products))",
-                                name=group[2],
-                                mode="markers",
-                                marker_symbol=group[3],
-                                marker_size=10,
-                                marker_color=group[4],
-                                marker_opacity=group[5])
-                )
-                first = false
-            end
-        end
-    end
-
-    first = true
-    for supplier in supply_chain.suppliers
-        if in(supplier, excluded_nodes)
-            continue
-        end
-        if sum(get_shipments(supply_chain, supplier, p, period) for p in supply_chain.products) > 1e-10
-            push!(traces,
-                scattergeo(;lat=[supplier.location.latitude],
-                            lon=[supplier.location.longitude],
-                            legendgroup="supplier",
-                            showlegend=first,
-                            hoverinfo="text",
-                            text="$(supplier.name)",
-                            name="suppliers",
-                            mode="markers",
-                            marker_symbol="circle",
-                            marker_size=10,
-                            marker_color="yellow")
-            )
-            first = false
-        end
-    end
-
-    for (i, customer) in enumerate(supply_chain.customers)
-        push!(traces,
-            scattergeo(;lat=[customer.location.latitude],
-                        lon=[customer.location.longitude],
-                        legendgroup="customer",
-                        showlegend=(i==1),
-                        hoverinfo="text",
-                        text="$(customer.name) - $(sum(get_shipments(supply_chain, customer, p, period) for p in supply_chain.products))",
-                        name="customers",
-                        mode="markers",
-                        marker_symbol="circle",
-                        marker_color="green",
-                        marker_opacity=0.35)
-        )
-    end
-
-    geo = attr(scope=geography,
-                showland=true,)
-
-    layout = Layout(;title=title, showlegend=showlegend, geo=geo)
-    return Plot(traces, layout)
-end
+function plot_network end
 
 """
     plot_costs(supply_chain)
 
 Plots the costs of operating the supply chain.
+
+Requires `PlotlyJS` and `Plots` to be loaded (see this file's top-of-file note).
 """
-function plot_costs(supply_chain)
-    trace1 = bar(;x=1:supply_chain.horizon,
-                 y=[value(supply_chain.optimization_model[:total_fixed_costs_per_period][t]) for t in 1:supply_chain.horizon],
-                 name="Fixed Costs")
-    trace2 = bar(;x=1:supply_chain.horizon,
-                 y=[value(supply_chain.optimization_model[:total_transportation_costs_per_period][t]) for t in 1:supply_chain.horizon],
-                 name="Transportation Costs")
-    trace3 = bar(;x=1:supply_chain.horizon,
-                 y=[value(supply_chain.optimization_model[:total_opening_costs_per_period][t]) for t in 1:supply_chain.horizon],
-                 name="Opening Costs")
-    trace4 = bar(;x=1:supply_chain.horizon,
-                 y=[value(supply_chain.optimization_model[:total_costs_per_period][t])  -
-                    (value(supply_chain.optimization_model[:total_fixed_costs_per_period][t]) +
-                     value(supply_chain.optimization_model[:total_transportation_costs_per_period][t]) +
-                     value(supply_chain.optimization_model[:total_opening_costs_per_period][t])
-                     ) for t in 1:supply_chain.horizon],
-                 name="Other Costs")
-
-    layout = Layout(;barmode="stack",
-                    xaxis_title="Period", xaxis_tick0=1, xaxis_dtick=1, xaxis_rangemode="nonnegative",
-                    yaxis_title="Cost (\$)")
-    Plot([trace1, trace2, trace3, trace4], layout)
-end
-
-"""
-    get_financials(supply_chain; max_time=supply_chain.horizon)
-
-Gets the financial results of operating the supply chain.
-"""
-function get_financials(supply_chain; max_time=supply_chain.horizon)
-    profits = collect(value.(supply_chain.optimization_model[:total_revenues_per_period]))[1:max_time].-collect(value.(supply_chain.optimization_model[:total_costs_per_period]))[1:max_time]
-    cum_profits = cumsum(profits, dims=1)
-
-    DataFrame((Horizon = 1:max_time,
-               Profits = profits,
-               Cumulative_Profits = cum_profits,
-               Revenues = collect(value.(supply_chain.optimization_model[:total_revenues_per_period]))[1:max_time],
-               Costs = collect(value.(supply_chain.optimization_model[:total_costs_per_period]))[1:max_time],
-               Transportation_Costs = collect(value.(supply_chain.optimization_model[:total_transportation_costs_per_period]))[1:max_time],
-               Holding_Costs = collect(value.(supply_chain.optimization_model[:total_holding_costs_per_period]))[1:max_time],
-               Buying_Costs = collect(value.(supply_chain.optimization_model[:total_buying_costs_per_period]))[1:max_time],
-               Warehouses_Fixed_Costs = [sum(value(supply_chain.optimization_model[:opened][w,t]) * w.fixed_cost for w in supply_chain.storages) for t in 1:max_time],
-               Opening_Costs = collect(value.(supply_chain.optimization_model[:total_opening_costs_per_period]))[1:max_time],
-               Closing_Costs = collect(value.(supply_chain.optimization_model[:total_closing_costs_per_period]))[1:max_time]))
-end
+function plot_costs end
 
 """
     plot_financials(supply_chain; max_time=supply_chain.horizon)
 
 Plots the financial results of operating the supply chain.
-"""
-function plot_financials(supply_chain; max_time=supply_chain.horizon, title="Supply chain financials")
-    financials = get_financials(supply_chain; max_time=max_time)
 
-    plot([scatter(;x=financials.Horizon, y=financials.Revenues, name="revenues"),
-        scatter(;x=financials.Horizon, y=financials.Costs, name="costs"),
-        scatter(;x=financials.Horizon, y=financials.Profits, name="profits"),
-        scatter(;x=financials.Horizon, y=financials.Cumulative_Profits, name="cumulative_profits"),
-        scatter(;x=financials.Horizon, y=financials.Transportation_Costs, name="transportation costs"),
-        scatter(;x=financials.Horizon, y=financials.Holding_Costs, name="holding costs"),
-        scatter(;x=financials.Horizon, y=financials.Buying_Costs, name="buying costs"),
-        scatter(;x=financials.Horizon, y=financials.Warehouses_Fixed_Costs, name="warehouse fixed costs"),
-        scatter(;x=financials.Horizon, y=financials.Opening_Costs, name="opening costs"),
-        scatter(;x=financials.Horizon, y=financials.Closing_Costs, name="closing costs"),
-        ],
-        Layout(;title=title))
-end
+Requires `PlotlyJS` and `Plots` to be loaded (see this file's top-of-file note).
+"""
+function plot_financials end
 
 """
     plot_flows(supply_chain, period=1; geography="usa", showlegend=true)
 
 Plots the flows of products in the supply chain.
+
+Requires `PlotlyJS` and `Plots` to be loaded (see this file's top-of-file note).
 """
-function plot_flows(supply_chain, period=1; geography="usa", showlegend=true, excluded_origins=[], origin_colors = Dict{Node, String}())
-
-    colors = ["red", "blue", "green", "orange", "black", "purple"]
-
-    color_index = length(origin_colors)
-
-    traces = AbstractTrace[]
-    for l in supply_chain.lanes #sort(collect(supply_chain.lanes), by=l->string(l.origin.location.name, l.destination.location.name))
-        if in(l.origin, excluded_origins)
-            continue
-        end
-        for d in l.destinations
-            if sum(get_shipments(supply_chain, l, d, p, period) for p in supply_chain.products) > 2e-10
-                if l.origin in keys(origin_colors)
-                    color = origin_colors[l.origin]
-                else
-                    color_index = mod1(color_index + 1, length(colors))
-                    color = colors[color_index]
-                    push!(origin_colors, l.origin => color)
-                end
-
-                push!(traces,
-                    scattergeo(;lat=[l.origin.location.latitude, d.location.latitude],
-                                lon=[l.origin.location.longitude, d.location.longitude],
-                                hoverinfo="text",
-                                text="$(l.origin.location.name) - $(d.location.name)",
-                                name="$(l.origin.location.name) - $(d.location.name)",
-                                mode="lines",
-                                line_color=color)
-                )
-            end
-        end
-    end
-
-    geo = attr(scope=geography,
-                showland=true,)
-
-    layout = Layout(;title="Supply chain flows", showlegend=showlegend, geo=geo)
-    Plot(traces, layout)
-end
-
-# Shared by animate_network/animate_flows below: given the per-period Plot
-# vector `ps` (one plot_network/plot_flows result per period), builds the
-# frame/slider/play-pause-button/layout scaffolding for a Plotly time
-# animation. The two callers differ only in how `ps` itself is built.
-function _animate(ps, supply_chain; geography, showlegend)
-    #generate the initial frame
-    trace = [scattergeo() for i in 1:length(getfield(ps[supply_chain.horizon], :data))]
-
-    #store all frames in a vector
-    frames = PlotlyFrame[
-        frame(
-            data = getfield(ps[k], :data),
-            layout = attr(title_text = "Period $k"), #update title
-            name = "frame_$k", #update frame name
-            traces = collect(1:length(getfield(ps[k], :data)))
-        ) for k = 1:supply_chain.horizon
-    ]
-
-    #define the slider for manually viewing the frames
-    sliders_attr = [
-        attr(
-            active = 0,
-            minorticklen = 0,
-            pad_t = 10,
-            steps = [
-                attr(
-                    method = "animate",
-                    label = "Period $k",
-                    args = [
-                        ["frame_$k"], #match the name of the frame again
-                        attr(
-                            mode = "immediate",
-                            transition = attr(duration = 0),
-                            frame = attr(duration = 5, redraw = true),
-                        ),
-                    ],
-                ) for k = 1:supply_chain.horizon
-            ],
-        ),
-    ]
-
-    #define the displaying time per played frame (in milliseconds)
-    dt_frame = 250
-
-    #define the play and pause buttons
-    buttons_attr = [
-        attr(
-            label = "Play",
-            method = "animate",
-            args = [
-                nothing,
-                attr(
-                    fromcurrent = true,
-                    transition = (duration = dt_frame,),
-                    frame = attr(duration = dt_frame, redraw = true),
-                ),
-            ],
-        ),
-        attr(
-            label = "Pause",
-            method = "animate",
-            args = [
-                [nothing],
-                attr(
-                    mode = "immediate",
-                    fromcurrent = true,
-                    transition = attr(duration = dt_frame),
-                    frame = attr(duration = dt_frame, redraw = true),
-                ),
-            ],
-        ),
-    ]
-
-    #layout for the plot
-    layout = Layout(
-        width = 1500,
-        height = 1000,
-        margin_b = 90,
-        # add buttons to play the animation
-        updatemenus = [
-            attr(
-                x = 0.5,
-                y = 0,
-                yanchor = "top",
-                xanchor = "center",
-                showactive = true,
-                direction = "left",
-                type = "buttons",
-                pad = attr(t = 90, r = 10),
-                buttons = buttons_attr,
-            ),
-        ],
-        #add the sliders
-        sliders = sliders_attr,
-
-        showlegend=showlegend,
-        geo = attr(scope=geography,
-                    showland=true,),
-    )
-
-    #save the plot and show it
-    return Plot(trace, layout, frames)
-end
+function plot_flows end
 
 """
     animate_network
 
 Creates an animation of the network through time.
+
+Requires `PlotlyJS` and `Plots` to be loaded (see this file's top-of-file note).
 """
-function animate_network(supply_chain;
-                         geography="usa",
-                         showlegend=true,
-                         excluded_nodes=[],
-                         groups=[(supply_chain.storages, "storage", "square", "blue", 1.0), (supply_chain.plants, "plant", "triangle-up", "red", 1.0)])
-    ps = [plot_network(supply_chain, i; geography=geography, showlegend=showlegend, excluded_nodes=excluded_nodes, groups=groups) for i in 1:supply_chain.horizon]
-    return _animate(ps, supply_chain; geography=geography, showlegend=showlegend)
-end
+function animate_network end
 
 """
     animate_flows; geography="usa", showlegend=true, excluded_origins=[])
 
 Creates an animation of the product flows through time.
+
+Requires `PlotlyJS` and `Plots` to be loaded (see this file's top-of-file note).
 """
-function animate_flows(supply_chain; geography="usa", showlegend=true, excluded_origins=[])
-    origin_colors = Dict{Node, String}()
-    ps = [plot_flows(supply_chain, i; geography=geography, showlegend=showlegend, excluded_origins=excluded_origins, origin_colors=origin_colors) for i in 1:supply_chain.horizon]
-    return _animate(ps, supply_chain; geography=geography, showlegend=showlegend)
-end
+function animate_flows end
 
 """
     movie_network
 
 Makes a movie of the network evolution.
+
+Requires `PlotlyJS` and `Plots` to be loaded (see this file's top-of-file note).
 """
-function movie_network(supply_chain, file_path;
-                        geography="usa",
-                        showlegend=true,
-                        excluded_nodes=[],
-                        groups=[(supply_chain.storages, "storage", "square", "blue", 1.0), (supply_chain.plants, "plant", "triangle-up", "red", 1.0)])
-    ps = [plot_network(supply_chain, i;
-                        geography=geography,
-                        showlegend=showlegend,
-                        excluded_nodes=excluded_nodes,
-                        groups=groups) for i in 1:supply_chain.horizon]
-
-    mktempdir() do dir
-        fnames = String[]
-        for (i, p) in enumerate(ps)
-            fname = lpad(i, 6, "0") * ".png"
-            push!(fnames, fname)
-            savefig(p, joinpath(dir, fname), width=700, height=500, scale=1)
-        end
-
-        anim = Plots.Animation(dir, fnames)
-        Plots.mp4(anim, file_path; fps=1)
-    end
-end
+function movie_network end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,11 @@ using SupplyChainOptimization
 #using Cbc
 using JuMP
 using Test
+# Loading PlotlyJS here is what activates SupplyChainOptimizationPlotlyJSExt
+# (see Project.toml's [weakdeps]/[extensions] and src/Visualization.jl) -
+# without it, plot_costs/plot_flows/plot_financials/plot_network/
+# animate_network/animate_flows below would all be plain MethodErrors.
+using PlotlyJS
 
 include("Models.jl")
 


### PR DESCRIPTION
## Why

`PlotlyJS` 0.18.x requires `JSON.jl` 0.20-0.21 (the pre-1.0 line). Anything needing modern `JSON.jl` 1.x (e.g. `Oxygen.jl`, which `ExcelAtRetail.jl`'s backend depends on) can't coexist with that in the same environment - no version of `JSON.jl` satisfies both, so `Pkg.instantiate()` fails outright for any consumer needing both, not just at plot time. Hit for real trying to instantiate `ExcelAtRetail.jl`'s backend.

`PlotlyJS`/`Plots` were unconditional dependencies only because `Visualization.jl` was unconditionally `include`d - nothing about the core optimization/querying functionality needs them.

## What changed

Split plotting into two package extensions, matching the granularity `test/Project.toml` already implied (it only ever declared `PlotlyJS`, never `Plots`):

- `ext/SupplyChainOptimizationPlotlyJSExt.jl` (triggered by `PlotlyJS` alone): `plot_inventory`, `plot_network`, `plot_costs`, `plot_financials`, `plot_flows`, `animate_network`, `animate_flows`.
- `ext/SupplyChainOptimizationPlotsExt.jl` (triggered by `PlotlyJS` + `Plots`): just `movie_network`, the one function needing `Plots.Animation`/`mp4`.

`get_financials` moved to `Querying.jl` - pure `DataFrame` construction, never touched `PlotlyJS`/`Plots`, so it stays available with neither extension loaded. `src/Visualization.jl` now holds just docstring'd stub declarations (`function name end`), keeping the names part of the exported API surface regardless of whether the extensions are active.

Also:
- Fixed what looks like a pre-existing latent bug while relocating `movie_network`: it referenced `Plots.Animation`/`Plots.mp4` (qualified) but only ever did `using Plots: Animation, buildanimation, mp4` (selective), which doesn't bind the `Plots` name itself. Likely never caught since `movie_network` isn't covered by any test (can't be, with plain `PlotlyJS` in `test/Project.toml`). Now calls the already-unqualified names directly.
- Added `using PlotlyJS` to `test/runtests.jl` so the `PlotlyJS` extension actually activates during CI - without it, every `plot_*`/`animate_*` call in the test suite would be a fresh `MethodError`.
- Dropped the `[sources]` override for `SupplyChainModeling`, now that it's a normal registered General dependency (v0.4.0+).

## Compatibility

Version bump: 0.4.1 → 0.5.0. Under this package's pre-1.0 versioning this counts as breaking (bare `using SupplyChainOptimization` without also loading `PlotlyJS`/`Plots` now gets a `MethodError` on the plot/animate functions instead of a working method) - flagging as such for the registry's release-notes requirement, though unlikely to affect real callers since a plotting function is useless without something to render the plot into.

## Testing

Not run against a real Julia install - no Julia runtime was available in the environment this was written in. Opening as a PR rather than merging directly (unlike the prior compat-only fixes) specifically so this repo's own CI exercises it before it reaches `main` or gets registered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7Jn1KCoPsbJmY45uGApz4)_