### PR TITLE
Fix CI: add warm_start_from_relaxation!/solve_relax_and_fix! to docs reference

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -5,6 +5,8 @@
 ```@docs
 minimize_cost!
 maximize_profits!
+warm_start_from_relaxation!
+solve_relax_and_fix!
 SupplyChainOptimization.create_network_cost_minimization_model
 SupplyChainOptimization.create_network_profit_maximization_model
 SupplyChainOptimization.create_network_cost_minimization_model!


### PR DESCRIPTION
## Summary

`main`'s Documentation CI check is currently failing after PR #18 merged:

```
Error: 2 docstrings not included in the manual:
    SupplyChainOptimization.warm_start_from_relaxation! :: Union{Tuple{Any, Symbol}, Tuple{Any, Symbol, Any}}
    SupplyChainOptimization.solve_relax_and_fix! :: Union{Tuple{Any, Symbol}, Tuple{Any, Symbol, Any}}

ERROR: LoadError: `makedocs` encountered an error [:missing_docs] -- terminating build before rendering.
```

Both functions are exported and carry docstrings (added in PR #18's original commit), but were never added to `docs/src/reference.md`. `Documenter`'s `checkdocs = :exports` requires every exported, docstring-carrying symbol to appear in a `@docs`/`@autodocs` block, so the docs build fails until they're listed.

This gap pre-dates the renumbering work (PR #19) - it was never caught because CI's `pull_request` trigger only runs against PRs targeting `main`, and PR #18 didn't target `main` until it was retargeted just before merging.

## Change

Adds both functions to the existing "Optimization" `@docs` block in `docs/src/reference.md`, alongside `minimize_cost!`/`maximize_profits!`.

## Test plan

- [ ] CI's Documentation check passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RthEbA2YP7C9sGee93K88o

---
_Generated by [Claude Code](https://claude.ai/code/session_01RthEbA2YP7C9sGee93K88o)_