### PR TITLE
Pin received[] to declared arrivals before a lane's lead time can deliver

### DIFF
--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -81,6 +81,27 @@ function create_network_model(supply_chain, optimizer, bigM=1_000_000; single_so
 
     @constraint(m, [p=products, l=lanes, t=times], sum(received[p, l, l.destinations[i], t + l.times[i]] for i in 1:length(l.destinations) if t + l.times[i] <= supply_chain.horizon) == sent[p, l, t])
 
+    # The constraint above only ties received[p, l, destination, t] to a
+    # real sent[] shipment for t reachable from an in-horizon departure
+    # (departure = t - l.times[i] >= 1, i.e. t > l.times[i] - see
+    # get_sent_time). For t <= l.times[i] there is no such departure - the
+    # horizon simply doesn't start early enough for any real shipment on
+    # this lane to have arrived yet - so without this constraint
+    # received[] for those periods is left as a free >= 0 variable, and
+    # the demand-balance constraint below (received + arrivals == demand -
+    # lost_sales) lets the solver set it to whatever demand requires, at
+    # zero transportation cost (that's computed from sent[], never
+    # received[]) and with nothing physically shipped. That silently
+    # defeats a customer's service_level whenever their fastest lane's
+    # lead time reaches into the start of the horizon - see the "Lost
+    # sales" testset below for the regression this guards. The only
+    # legitimate source for something arriving before any in-horizon
+    # shipment could reach it is a lane's declared initial_arrivals
+    # (get_arrivals - 0 when none is declared), so pin received[] to
+    # exactly that instead of leaving it free.
+    @constraint(m, [p=products, l=lanes, i=1:length(l.destinations), t=times; t <= l.times[i]],
+        received[p, l, l.destinations[i], t] == get_arrivals(p, l, l.destinations[i], t))
+
     @constraint(m, [l=lanes], sum(sent[p, l, t] for p in products, t in times if !can_ship(l, t)) == 0)
     @constraint(m, [l=lanes, t=times; l.minimum_quantity > 0 || l.fixed_cost > 0], sum(sent[p, l, t] for p in products) <= bigM * used[l, t])
     @constraint(m, [l=lanes, t=times; l.minimum_quantity > 0], sum(sent[p, l, t] for p in products) >= l.minimum_quantity * used[l, t])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,6 +192,49 @@ end
     @test financials.Costs[1] ≈ 120.0
 end
 
+@testset "Lost sales forced by a lane's lead time, not just by inventory" begin
+    # Same idea as the "Lost sales" testset above, but the shortfall is
+    # forced by the lane's own transit time instead of insufficient
+    # inventory: period-1 demand behind a lane with time=1 physically
+    # cannot be met (nothing departs before period 1, and it takes 1
+    # period to arrive - the earliest anything could arrive is period 2,
+    # which doesn't exist in a 1-period horizon), no matter how much
+    # inventory the storage holds or how profitable shipping would be.
+    #
+    # Regression test for the missing constraint on received[] added
+    # above: before it, received[p, lane, c, 1] was a free >= 0 variable
+    # for exactly this lane/period (get_sent_time(lane, c, 1) == 0, not
+    # > 0, so the demand-cap constraint a few lines up never applied to
+    # it either) - the solver could (and did) just set it to 100.0 to
+    # make the demand-balance constraint (received + arrivals == demand -
+    # lost_sales) come out even for free, reporting zero lost sales
+    # despite nothing being physically shippable that fast. With the new
+    # constraint pinning it to get_arrivals(...) (0 here - no
+    # initial_arrivals declared), the shortfall now has nowhere to hide.
+    sc = SupplyChain(1)
+
+    product = Product("p1")
+    add_product!(sc, product)
+
+    c = Customer("c1", Seattle)
+    add_customer!(sc, c)
+    add_demand!(sc, c, product, [100.0]; sales_price=10.0, lost_sales_cost=3.0, service_level=0.0)
+
+    storage = Storage("s1", Seattle; fixed_cost=0.0, initial_opened=true)
+    add_storage!(sc, storage)
+    add_product!(storage, product; initial_inventory=1000.0) # plenty of stock - the lane's lead time is the only obstacle
+
+    add_lane!(sc, Lane(storage, c; unit_cost=0.0, time=1))
+
+    SupplyChainOptimization.maximize_profits!(sc)
+
+    financials = get_financials(sc)
+
+    @test get_lost_sales(sc, c, product, 1) ≈ 100.0
+    @test financials.Lost_Sales[1] ≈ 100.0
+    @test financials.Lost_Sales_Cost[1] ≈ 300.0
+end
+
 @testset "Lost sales cost influences the objective" begin
     # Shipping alone loses money here (sales_price=10 < lane unit_cost=12), so
     # with lost_sales_cost=0 the optimizer strictly prefers losing the sale


### PR DESCRIPTION
## Summary

Found while debugging ExcelAtRetail.jl: a customer whose fastest lane couldn't physically deliver by period 1 (100% `service_level`) was correctly flagged as unreachable by our pre-solve reachability check, yet the actual solve reported `$0` lost sales for it.

**Root cause**: `received[p, l, l.destinations[i], t + l.times[i]] == sent[p, l, t]` (`Optimization.jl:82`) only ties `received[...]` to a real shipment for `t` reachable from an in-horizon departure (`t > l.times[i]`). For `t <= l.times[i]` — earlier than any in-horizon shipment could possibly arrive — `received[...]` was left as a free `>= 0` variable. The demand-balance constraint (`received + arrivals == demand - lost_sales`) then let the solver set that free variable to exactly match demand, at zero transportation cost (cost is computed from `sent[]`, never `received[]`), with nothing physically shipped. That silently defeats `service_level` whenever a demand period falls within a lane's lead time of the horizon start.

This isn't about `initial_arrivals`/`get_arrivals` being unsupported — that mechanism already exists precisely for legitimately declaring shipments in transit before the horizon starts. The bug is that `received[]` isn't pinned to it (or to 0, absent a declaration) when no `sent[]` shipment could have produced it.

**Fix**: a new constraint pins `received[p, l, destination, t]` to exactly `get_arrivals(p, l, destination, t)` for every `t <= l.times[i]` — the same set of periods the sent↔received linking constraint above doesn't reach.

**Test**: added alongside the existing "Lost sales" testset, forcing the shortfall via a lane's lead time (with ample inventory and a free lane) rather than via insufficient inventory, to isolate this specific gap from the already-covered inventory-shortfall case.

## Note for reviewers

- The same bug pattern exists on `main` (`received[]` there is index-mapped differently - `pidx`/`lidx`/`effective_bigM` instead of direct object indexing - so this PR doesn't attempt to port the fix there; flagging for a maintainer to look at separately).
- **Not run against a live Julia process** - no Julia runtime was available in the environment this was authored in. CI on this PR (triggers on PRs into `main` only, per `.github/workflows/ci.yml` - won't auto-run against this base) is the first real execution; recommend running the test suite manually against this branch, or retargeting to `main` if that's easier to get CI signal from.
- Also worth checking whether the same gap affects storage/plant inventory balance, which reads the same `received[]` variable (`Optimization.jl:120`, `:140`) - this fix's new constraint applies to all lane destinations generally (not just customers), so it should already cover those too, but worth confirming deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YZ72BnSVJCushgEKjVcT4

---
_Generated by [Claude Code](https://claude.ai/code/session_017YZ72BnSVJCushgEKjVcT4)_